### PR TITLE
ResetHomeEnvironmentVariable takes no effect.

### DIFF
--- a/GitCommands/Git/GitCommandHelpers.cs
+++ b/GitCommands/Git/GitCommandHelpers.cs
@@ -92,22 +92,7 @@ namespace GitCommands
             }
 
             // HOME variable
-
-            if (!string.IsNullOrEmpty(AppSettings.CustomHomeDir))
-            {
-                // Assign the HOME variable specified in settings
-                Environment.SetEnvironmentVariable("HOME", AppSettings.CustomHomeDir);
-            }
-            else if (AppSettings.UserProfileHomeDir)
-            {
-                // Assign the USERPROFILE variable's value to the HOME variable
-                Environment.SetEnvironmentVariable("HOME", Environment.GetEnvironmentVariable("USERPROFILE"));
-            }
-            else
-            {
-                // Assign a default HOME variable
-                Environment.SetEnvironmentVariable("HOME", GetDefaultHomeDir());
-            }
+            Environment.SetEnvironmentVariable("HOME", ComputeHomeLocation());
 
             // TERM variable
 
@@ -131,13 +116,20 @@ namespace GitCommands
             }
         }
 
-        /// <summary>
-        /// Reverts the process's <c>HOME</c> environment variable to the equivalent user/machine value.
-        /// </summary>
-        public static void ResetHomeEnvironmentVariable()
+        private static string ComputeHomeLocation()
         {
-            // Assign the HOME variable of the user/machine to this process
-            Environment.SetEnvironmentVariable("HOME", UserHomeDir);
+            if (!string.IsNullOrEmpty(AppSettings.CustomHomeDir))
+            {
+                return AppSettings.CustomHomeDir;
+            }
+            else if (AppSettings.UserProfileHomeDir)
+            {
+                return Environment.GetEnvironmentVariable("USERPROFILE");
+            }
+            else
+            {
+                return GetDefaultHomeDir();
+            }
         }
 
         /// <summary>

--- a/GitUI/CommandsDialogs/FormSettings.cs
+++ b/GitUI/CommandsDialogs/FormSettings.cs
@@ -252,9 +252,6 @@ namespace GitUI.CommandsDialogs
                 FormFixHome.CheckHomePath();
             }
 
-            // TODO: to which settings page does this belong?
-            GitCommandHelpers.ResetHomeEnvironmentVariable();
-
             // TODO: this method has a generic sounding name but only saves some specific settings
             AppSettings.SaveSettings();
 

--- a/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -223,8 +223,7 @@ namespace GitUI.CommandsDialogs.SettingsDialog.Pages
 
             AppSettings.UserProfileHomeDir = userprofileHome.Checked;
 
-            GitCommandHelpers.ResetHomeEnvironmentVariable();
-
+            GitCommandHelpers.SetEnvironmentVariables();
             string path = Environment.GetEnvironmentVariable("HOME");
             if (!Directory.Exists(path) || string.IsNullOrEmpty(path))
             {


### PR DESCRIPTION
It seems you were right that the reload parameter is not needed as it is immediately overridden.