### PR TITLE
Branch Graph Antialiasing

### DIFF
--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -767,18 +767,24 @@ namespace GitUI.UserControls.RevisionGrid
                                 {
                                     if (sameLane)
                                     {
-                                        g.SmoothingMode = SmoothingMode.AntiAlias;
+                                        g.SmoothingMode = SmoothingMode.None;
                                         g.DrawLine(linePen, p0, p1);
                                     }
                                     else
                                     {
+                                        // Anti-aliasing seems to introduce an offset of two thirds
+                                        // of a pixel to the right - compensate it.
+                                        g.SmoothingMode = SmoothingMode.AntiAlias;
+                                        float offset = -0.667F;
+
                                         // Left shifting int is fast equivalent of dividing by two,
                                         // thus computing the average of y0 and y1.
                                         var yMid = (y0 + y1) >> 1;
-                                        var c0 = new Point(x0, yMid);
-                                        var c1 = new Point(x1, yMid);
-                                        g.SmoothingMode = SmoothingMode.AntiAlias;
-                                        g.DrawBezier(linePen, p0, c0, c1, p1);
+                                        var c0 = new PointF(offset + x0, yMid);
+                                        var c1 = new PointF(offset + x1, yMid);
+                                        var e0 = new PointF(offset + p0.X, p0.Y);
+                                        var e1 = new PointF(offset + p1.X, p1.Y);
+                                        g.DrawBezier(linePen, e0, c0, c1, e1);
                                     }
                                 }
                             }

--- a/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -767,7 +767,7 @@ namespace GitUI.UserControls.RevisionGrid
                                 {
                                     if (sameLane)
                                     {
-                                        g.SmoothingMode = SmoothingMode.None;
+                                        g.SmoothingMode = SmoothingMode.AntiAlias;
                                         g.DrawLine(linePen, p0, p1);
                                     }
                                     else


### PR DESCRIPTION
Changes proposed in this pull request:
- avoid horizontal offset between perpendicular branch lines and Bezier curved ones
 
Screenshots before and after (if PR changes UI):
![grafik](https://user-images.githubusercontent.com/36601201/41564111-24ee3530-7352-11e8-9a1a-ac998e73321b.png) (zoom factor 2x of screenshot on Windows 7 with scaling factor 100%)
![grafik](https://user-images.githubusercontent.com/36601201/41822908-23743444-77f7-11e8-9c08-d3c09a1f958a.png)
![grafik](https://user-images.githubusercontent.com/36601201/41822915-47e457d2-77f7-11e8-80af-cc0d3b4536dd.png)

What did I do to test the code and ensure quality:
- run GE

Has been tested on (remove any that don't apply):
- GIT: N/A
- Windows 7