### PR TITLE
perf(ObjectId): convert from sealed class to readonly struct

### DIFF
--- a/src/app/GitCommands/AppTitleGenerator.cs
+++ b/src/app/GitCommands/AppTitleGenerator.cs
@@ -81,7 +81,7 @@ public sealed class AppTitleGenerator : IAppTitleGenerator
     public static void Initialise(string sha, string buildBranch)
     {
 #if DEBUG
-        if (ObjectId.TryParse(sha, out ObjectId? objectId))
+        if (ObjectId.TryParse(sha, out ObjectId objectId))
         {
             _extraInfo = $" {objectId.ToShortString()}";
             if (!string.IsNullOrWhiteSpace(buildBranch))

--- a/src/app/GitCommands/ArgumentBuilderExtensions.cs
+++ b/src/app/GitCommands/ArgumentBuilderExtensions.cs
@@ -230,11 +230,32 @@ public static class ArgumentBuilderExtensions
     /// <summary>
     /// Adds <paramref name="objectId"/> as a SHA-1 argument.
     /// </summary>
+    /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>
+    /// <param name="objectId">The SHA-1 object ID to add to the builder.</param>
+    /// <exception cref="ArgumentException"><paramref name="objectId"/> does not represent a real git object.</exception>
+    public static void Add(this ArgumentBuilder builder, ObjectId objectId)
+    {
+        if (objectId.IsZeroOrArtificial)
+        {
+            if (objectId.IsZero)
+            {
+                return;
+            }
+
+            throw new ArgumentException("Unexpected artificial commit in Git command: " + objectId);
+        }
+
+        builder.Add(objectId.ToString());
+    }
+
+    /// <summary>
+    /// Adds <paramref name="objectId"/> as a SHA-1 argument.
+    /// </summary>
     /// <remarks>
-    /// If <paramref name="objectId"/> is <c>null</c> then no change is made to the arguments.
+    /// If <paramref name="objectId"/> is <see langword="null"/> or zero, no change is made to the arguments.
     /// </remarks>
     /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>
-    /// <param name="objectId">The SHA-1 object ID to add to the builder, or <c>null</c>.</param>
+    /// <param name="objectId">The SHA-1 object ID to add to the builder, or <see langword="null"/>.</param>
     /// <exception cref="ArgumentException"><paramref name="objectId"/> represents an artificial commit.</exception>
     public static void Add(this ArgumentBuilder builder, ObjectId? objectId)
     {
@@ -243,12 +264,26 @@ public static class ArgumentBuilderExtensions
             return;
         }
 
-        if (objectId.IsArtificial)
+        builder.Add(objectId.Value);
+    }
+
+    /// <summary>
+    /// Adds a sequence of <paramref name="objectIds"/> to the builder.
+    /// </summary>
+    /// <param name="builder">The <see cref="ArgumentBuilder"/> to add arguments to.</param>
+    /// <param name="objectIds">A sequence of SHA-1 object IDs to add to the builder, or <see langword="null"/>.</param>
+    /// <exception cref="ArgumentException"><paramref name="objectIds"/> contains an artificial commit.</exception>
+    public static void Add(this ArgumentBuilder builder, IEnumerable<ObjectId>? objectIds)
+    {
+        if (objectIds is null)
         {
-            throw new ArgumentException("Unexpected artificial commit in Git command: " + objectId);
+            return;
         }
 
-        builder.Add(objectId.ToString());
+        foreach (ObjectId objectId in objectIds)
+        {
+            builder.Add(objectId);
+        }
     }
 
     /// <summary>

--- a/src/app/GitCommands/CommitDataManager.cs
+++ b/src/app/GitCommands/CommitDataManager.cs
@@ -117,11 +117,6 @@ public sealed class CommitDataManager : ICommitDataManager
     {
         ArgumentNullException.ThrowIfNull(revision);
 
-        if (revision.ObjectId is null)
-        {
-            throw new ArgumentException($"Cannot have a null {nameof(GitRevision.ObjectId)}.", nameof(revision));
-        }
-
         return new CommitData(revision.ObjectId, revision.ParentIds,
             FormatUser(revision.Author, revision.AuthorEmail), revision.AuthorDate,
             FormatUser(revision.Committer, revision.CommitterEmail), revision.CommitDate,

--- a/src/app/GitCommands/Git/Commands.cs
+++ b/src/app/GitCommands/Git/Commands.cs
@@ -58,11 +58,6 @@ public static partial class Commands
 
         static void Validate(GitCreateTagArgs gitCreateTagArgs, string? tagMessageFileName)
         {
-            if (gitCreateTagArgs.ObjectId is null)
-            {
-                throw new ArgumentException("Revision is required.");
-            }
-
             if (string.IsNullOrWhiteSpace(gitCreateTagArgs.TagName))
             {
                 throw new ArgumentException("TagName is required.");

--- a/src/app/GitCommands/Git/GitCreateTagArgs.cs
+++ b/src/app/GitCommands/Git/GitCreateTagArgs.cs
@@ -16,6 +16,11 @@ public class GitCreateTagArgs
     /// <param name="force">Force parameter</param>
     public GitCreateTagArgs(string tagName, ObjectId objectId, TagOperation operation = TagOperation.Lightweight, string tagMessage = "", string signKeyId = "", bool force = false)
     {
+        if (objectId.IsZeroOrArtificial)
+        {
+            throw new ArgumentException("A valid, non-artificial revision is required for tagging.", nameof(objectId));
+        }
+
         TagName = tagName;
         ObjectId = objectId;
         Operation = operation;

--- a/src/app/GitCommands/Git/GitItem.cs
+++ b/src/app/GitCommands/Git/GitItem.cs
@@ -15,6 +15,7 @@ public class GitItem : IObjectGitItem
     }
 
     public ObjectId ObjectId { get; }
+    ObjectId? IGitItem.ObjectId => ObjectId;
     public GitObjectType ObjectType { get; }
     public string Name { get; }
     public string FileName { get; set; }

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -866,7 +866,7 @@ public sealed partial class GitModule : IGitModule
 
     public string GetCommitCountString(ObjectId fromId, string to)
     {
-        bool cache = !fromId.IsArtificial && ObjectId.TryParse(to, out ObjectId? toId) && !toId.IsArtificial;
+        bool cache = !fromId.IsArtificial && ObjectId.TryParse(to, out ObjectId toId) && !toId.IsArtificial;
         (int? added, int? removed) = GetRevListLeftRightCount(fromId, to, cache);
 
         if (removed is null || added is null)
@@ -1046,12 +1046,12 @@ public sealed partial class GitModule : IGitModule
         GitArgumentBuilder args = new("rev-parse") { "HEAD" };
         ExecutionResult result = GitExecutable.Execute(args, throwOnErrorExit: false);
 
-        return result.ExitedSuccessfully && ObjectId.TryParse(result.StandardOutput, offset: 0, out ObjectId? objectId)
+        return result.ExitedSuccessfully && ObjectId.TryParse(result.StandardOutput, offset: 0, out ObjectId objectId)
             ? objectId
             : null;
     }
 
-    public bool TryResolvePartialCommitId(string objectIdPrefix, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
+    public bool TryResolvePartialCommitId(string objectIdPrefix, out ObjectId objectId)
     {
         // If the prefix is already a full SHA1 then return immediately without invoking a git process.
         if (ObjectId.TryParse(objectIdPrefix, out objectId))
@@ -1101,7 +1101,7 @@ public sealed partial class GitModule : IGitModule
         string submodule = lines[0];
 
         if (submodule.Length < ObjectId.Sha1CharCount + 3
-            || !ObjectId.TryParse(submodule, 1, out ObjectId? commitId))
+            || !ObjectId.TryParse(submodule, 1, out ObjectId commitId))
         {
             return (' ', null);
         }
@@ -1239,7 +1239,7 @@ public sealed partial class GitModule : IGitModule
             string localPath = match.Groups["path"].Value;
             string branch = match.Groups["branch"].Value;
 
-            if (!ObjectId.TryParse(match.Groups["sha"].Value, out ObjectId? currentCommitId))
+            if (!ObjectId.TryParse(match.Groups["sha"].Value, out ObjectId currentCommitId))
             {
                 info = default;
                 return false;
@@ -1497,7 +1497,7 @@ public sealed partial class GitModule : IGitModule
         }
 
         // Reset to index has no revision string
-        string revStr = revision == ObjectId.IndexId ? "" : revision?.ToString() ?? RevParse("HEAD")!.ToString();
+        string revStr = revision == ObjectId.IndexId ? "" : (revision ?? RevParse("HEAD"))?.ToString() ?? "";
 
         // Run batch arguments to work around max command line length on Windows. Fix #6593
         // 3: double quotes + ' '
@@ -2552,8 +2552,8 @@ public sealed partial class GitModule : IGitModule
         {
             staged = StagedStatus.Index;
         }
-        else if (firstId is not null && !firstId.IsArtificial &&
-                 secondId is not null && !secondId.IsArtificial)
+        else if (firstId is not null && !firstId.Value.IsArtificial &&
+                 secondId is not null && !secondId.Value.IsArtificial)
         {
             // This cannot be a worktree/index file
             staged = StagedStatus.None;
@@ -2624,7 +2624,7 @@ public sealed partial class GitModule : IGitModule
             "--max-count=1"
         };
         ExecutionResult executionResult = GitExecutable.Execute(args, throwOnErrorExit: false);
-        if (executionResult.ExitedSuccessfully && ObjectId.TryParse(executionResult.StandardOutput, out ObjectId? treeId))
+        if (executionResult.ExitedSuccessfully && ObjectId.TryParse(executionResult.StandardOutput, out ObjectId treeId))
         {
             IEnumerable<GitItemStatus> files = GetTreeFiles(treeId, full: true)
                 .Select(i =>
@@ -3375,15 +3375,18 @@ public sealed partial class GitModule : IGitModule
                 // The contents of the actual line is output after the above header, prefixed by a TAB. This is to allow adding more header elements later.
                 string text = ReEncodeStringFromLossless(line[1..], encoding);
 
+                // objectId is guaranteed to be set by the preceding git blame header line
+                ObjectId oid = objectId ?? default;
+
                 GitBlameCommit commit;
                 if (hasCommitHeader)
                 {
                     // TODO quite a few nullable suppressions here (via ! character) which should be addressed as they hint at a design flaw
 
-                    if (!commitByObjectId.TryGetValue(objectId!, out GitBlameCommit? commitData))
+                    if (!commitByObjectId.TryGetValue(oid, out GitBlameCommit? commitData))
                     {
                         commit = new GitBlameCommit(
-                            objectId!,
+                            oid,
                             author!,
                             authorMail!,
                             authorTime,
@@ -3394,7 +3397,7 @@ public sealed partial class GitModule : IGitModule
                             committerTimeZone!,
                             summary!,
                             filename!);
-                        commitByObjectId[objectId!] = commit;
+                        commitByObjectId[oid] = commit;
                     }
                     else
                     {
@@ -3421,7 +3424,7 @@ public sealed partial class GitModule : IGitModule
                 }
                 else
                 {
-                    commit = commitByObjectId[objectId!];
+                    commit = commitByObjectId[oid];
                 }
 
                 lines.Add(new GitBlameLine(commit, finalLineNumber, originLineNumber, text));
@@ -3616,7 +3619,7 @@ public sealed partial class GitModule : IGitModule
             return null;
         }
 
-        if (ObjectId.TryParse(revisionExpression, out ObjectId? objectId))
+        if (ObjectId.TryParse(revisionExpression, out ObjectId objectId))
         {
             return objectId;
         }
@@ -3649,7 +3652,7 @@ public sealed partial class GitModule : IGitModule
         ExecutionResult result = GitExecutable.Execute(args, cache: GitCommandCache, throwOnErrorExit: false);
         string output = result.StandardOutput;
 
-        return ObjectId.TryParse(output, offset: 0, out ObjectId? objectId)
+        return ObjectId.TryParse(output, offset: 0, out ObjectId objectId)
             ? objectId
             : null;
     }

--- a/src/app/GitCommands/Git/GitSubmoduleInfo.cs
+++ b/src/app/GitCommands/Git/GitSubmoduleInfo.cs
@@ -12,12 +12,12 @@ public sealed class GitSubmoduleInfo : IGitSubmoduleInfo
     public bool IsInitialized { get; }
     public bool IsUpToDate { get; }
 
-    public GitSubmoduleInfo(string name, string localPath, string remotePath, ObjectId currentCommitGuid, string branch, bool isInitialized, bool isUpToDate)
+    public GitSubmoduleInfo(string name, string localPath, string remotePath, ObjectId currentCommitId, string branch, bool isInitialized, bool isUpToDate)
     {
         Name = name ?? throw new ArgumentNullException(nameof(name));
         LocalPath = localPath ?? throw new ArgumentNullException(nameof(localPath));
         RemotePath = remotePath ?? throw new ArgumentNullException(nameof(remotePath));
-        CurrentCommitId = currentCommitGuid ?? throw new ArgumentNullException(nameof(currentCommitGuid));
+        CurrentCommitId = currentCommitId;
         Branch = branch ?? throw new ArgumentNullException(nameof(branch));
         IsInitialized = isInitialized;
         IsUpToDate = isUpToDate;

--- a/src/app/GitCommands/Git/SubmoduleHelpers.cs
+++ b/src/app/GitCommands/Git/SubmoduleHelpers.cs
@@ -131,7 +131,7 @@ public static partial class SubmoduleHelpers
             }
             else if (submodule.IsValidGitWorkingDir())
             {
-                (addedCommits, removedCommits) = submodule.GetCommitRangeDiffCount(commitId, oldCommitId);
+                (addedCommits, removedCommits) = submodule.GetCommitRangeDiffCount(commitId.Value, oldCommitId.Value);
             }
         }
 

--- a/src/app/GitCommands/RevisionReader.cs
+++ b/src/app/GitCommands/RevisionReader.cs
@@ -178,11 +178,13 @@ public sealed class RevisionReader
     public async Task<GitRevision?> GetRevisionAsync(string commitHash, bool hasNotes, bool throwOnError, CancellationToken cancellationToken)
     {
         // output can be cached if git-notes is not included and hash is a sha.
-        bool doCacheGitOutput = ObjectId.TryParse(commitHash, out ObjectId? objectId) && !hasNotes;
-        if (objectId?.IsArtificial is true)
+        bool isValidSha = ObjectId.TryParse(commitHash, out ObjectId objectId);
+        if (isValidSha && objectId.IsArtificial)
         {
             throw new InvalidOperationException(nameof(commitHash));
         }
+
+        bool doCacheGitOutput = isValidSha && !hasNotes;
 
         GitArgumentBuilder arguments = new("log")
         {
@@ -355,7 +357,7 @@ public sealed class RevisionReader
     {
         string autoStashFileName = Path.Combine(workingDirGitDir, "rebase-merge/autostash");
         if (!File.Exists(autoStashFileName)
-            || !ObjectId.TryParse(File.ReadLines(autoStashFileName).FirstOrDefault(), out ObjectId? autoStashCommitId))
+            || !ObjectId.TryParse(File.ReadLines(autoStashFileName).FirstOrDefault(), out ObjectId autoStashCommitId))
         {
             return;
         }
@@ -371,7 +373,7 @@ public sealed class RevisionReader
 
         string origHeadFileName = Path.Combine(workingDirGitDir, "rebase-merge/orig-head");
         if (File.Exists(origHeadFileName)
-            && ObjectId.TryParse(File.ReadLines(origHeadFileName).FirstOrDefault(), out ObjectId? origHeadCommitId))
+            && ObjectId.TryParse(File.ReadLines(origHeadFileName).FirstOrDefault(), out ObjectId origHeadCommitId))
         {
             autoStashRevision.ParentIds = [origHeadCommitId];
         }
@@ -420,7 +422,7 @@ public sealed class RevisionReader
         // The first 40 bytes are the revision ID and the tree ID back to back
         ReadOnlyMemory<byte> commitHash = buffer.Slice(0, ObjectId.Sha1CharCount);
         ReadOnlySpan<byte> commitHashSpan = commitHash.Span;
-        ObjectId? objectId;
+        ObjectId objectId;
         if (_cache is not null && commitHashSpan.SequenceEqual(_cache.Value.buffer.Span))
         {
             objectId = _cache.Value.objectId;
@@ -436,7 +438,7 @@ public sealed class RevisionReader
         }
 
         ReadOnlyMemory<byte> parentCommitHash = buffer.Slice(ObjectId.Sha1CharCount, ObjectId.Sha1CharCount);
-        if (!ObjectId.TryParse(parentCommitHash.Span, out ObjectId? treeId))
+        if (!ObjectId.TryParse(parentCommitHash.Span, out ObjectId treeId))
         {
             ParseAssert($"Log parse error, object id: {buffer.Length}({parentCommitHash}");
             revision = default;
@@ -488,7 +490,7 @@ public sealed class RevisionReader
             for (int parentIndex = 0; parentIndex < noParents; parentIndex++)
             {
                 ReadOnlyMemory<byte> hashParent = buffer.Slice(offset, ObjectId.Sha1CharCount);
-                if (!ObjectId.TryParse(hashParent.Span, out ObjectId? parentId))
+                if (!ObjectId.TryParse(hashParent.Span, out ObjectId parentId))
                 {
                     ParseAssert($"Log parse error, parent {parentIndex} for {objectId}");
                     revision = default;

--- a/src/app/GitExtensions.Extensibility/Git/GitRevision.cs
+++ b/src/app/GitExtensions.Extensibility/Git/GitRevision.cs
@@ -28,7 +28,12 @@ public sealed partial class GitRevision : IGitItem, INotifyPropertyChanged
 
     public GitRevision(ObjectId objectId)
     {
-        ObjectId = objectId ?? throw new ArgumentNullException(nameof(objectId));
+        if (objectId.IsZero)
+        {
+            throw new ArgumentException("ObjectId must not be the default (zero) value.", nameof(objectId));
+        }
+
+        ObjectId = objectId;
     }
 
     /// <summary>
@@ -41,6 +46,11 @@ public sealed partial class GitRevision : IGitItem, INotifyPropertyChanged
     }
 
     public ObjectId ObjectId { get; }
+
+    /// <summary>
+    /// Explicit interface implementation to satisfy the nullable <see cref="IGitItem.ObjectId"/> contract.
+    /// </summary>
+    ObjectId? IGitItem.ObjectId => ObjectId;
 
     public string Guid => ObjectId.ToString();
 

--- a/src/app/GitExtensions.Extensibility/Git/GitSubmoduleStatus.cs
+++ b/src/app/GitExtensions.Extensibility/Git/GitSubmoduleStatus.cs
@@ -34,9 +34,9 @@ public sealed class GitSubmoduleStatus
 
     // Get CommitData without Notes (will cache contents)
     public CommitData? CommitData
-        => GetCommitData is not null && Commit is not null ? GetCommitData(Commit.ToString()) : null;
+        => GetCommitData is not null && Commit is not null ? GetCommitData(Commit.Value.ToString()) : null;
     public CommitData? OldCommitData
-        => GetCommitData is not null && OldCommit is not null ? GetCommitData(OldCommit.ToString()) : null;
+        => GetCommitData is not null && OldCommit is not null ? GetCommitData(OldCommit.Value.ToString()) : null;
 
     public GitSubmoduleStatus(string name, string? oldName, bool isDirty, ObjectId? commit, ObjectId? oldCommit, int? addedCommits, int? removedCommits, Func<string, CommitData?>? getCommitData, Func<GitSubmoduleStatus, SubmoduleStatus> getSubmoduleStatus)
     {

--- a/src/app/GitExtensions.Extensibility/Git/IGitItem.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitItem.cs
@@ -2,6 +2,13 @@
 
 public interface IGitItem
 {
+    /// <summary>
+    /// Gets the object ID, or <see langword="null"/> if not known.
+    /// </summary>
+    /// <remarks>
+    /// Nullable because some implementations (e.g. <c>GitRef</c>) may not have a resolved object ID,
+    /// such as when representing remote tracking configurations or the <c>NoHead</c> sentinel.
+    /// </remarks>
     ObjectId? ObjectId { get; }
 
     string? Guid { get; }

--- a/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
+++ b/src/app/GitExtensions.Extensibility/Git/IGitModule.cs
@@ -149,7 +149,7 @@ public interface IGitModule
     /// <returns>The path in Windows format with native file separators.</returns>
     public string GetWindowsPath(string path);
 
-    bool TryResolvePartialCommitId(string objectIdPrefix, [NotNullWhen(returnValue: true)] out ObjectId? objectId);
+    public bool TryResolvePartialCommitId(string objectIdPrefix, out ObjectId objectId);
 
     string GetSubmoduleFullPath(string localPath);
 

--- a/src/app/GitExtensions.Extensibility/Git/ObjectId.cs
+++ b/src/app/GitExtensions.Extensibility/Git/ObjectId.cs
@@ -14,10 +14,10 @@ namespace GitExtensions.Extensibility.Git;
 /// <remarks>
 /// <para>Instances are immutable and are guaranteed to contain valid, 160-bit (20-byte) SHA1 hashes.</para>
 /// <para>String forms of this object must be in lower case.</para>
-/// <para>Data is stored in a fixed-size 20-byte buffer in big-endian byte order (SHA-1 natural order),
-/// enabling direct hex conversion and SIMD-accelerated equality, comparison, and zero-checks.</para>
+/// <para>Data is stored in big-endian byte order (SHA-1 natural order), enabling direct hex
+/// conversion and SIMD-accelerated equality, comparison, and zero-checks.</para>
 /// </remarks>
-public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>
+public readonly struct ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>
 {
     private static readonly SearchValues<char> _hexChars = SearchValues.Create("0123456789abcdef");
     private static readonly Random _random = new();
@@ -48,7 +48,28 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>
         return new ObjectId(data);
     }
 
+    /// <summary>
+    /// Gets whether this instance is the default (all-zeroes) value, indicating no valid object.
+    /// </summary>
+    public bool IsZero
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> bytes = _data;
+            ref byte start = ref Unsafe.AsRef(in MemoryMarshal.GetReference(bytes));
+            return Vector128.LoadUnsafe(ref start) == Vector128<byte>.Zero
+                && Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref start, 16)) == 0;
+        }
+    }
+
     public bool IsArtificial => this == WorkTreeId || this == IndexId || this == CombinedDiffId;
+
+    /// <summary>
+    /// Gets whether this instance does not represent a real git object — either
+    /// the default (all-zeroes) value or one of the artificial sentinel values.
+    /// </summary>
+    public bool IsZeroOrArtificial => IsZero || IsArtificial;
 
     private const int _sha1ByteCount = 20;
     public const int Sha1CharCount = 40;
@@ -78,6 +99,9 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int HexNibble(int c)
     {
+        // Branchless lookup: digits 0x30–0x39, uppercase 0x41–0x46, lowercase 0x61–0x66.
+        // Subtract '0'; if result < 10, it's a digit.
+        // Otherwise subtract gap to A/a and check range.
         int digit = c - '0';
         if ((uint)digit < 10)
         {
@@ -156,7 +180,7 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>
     [Pure]
     public static ObjectId Parse(string s)
     {
-        if (s?.Length is not Sha1CharCount || !TryParse(s.AsSpan(), out ObjectId? id))
+        if (s?.Length is not Sha1CharCount || !TryParse(s.AsSpan(), out ObjectId id))
         {
             throw new FormatException($"Unable to parse object ID \"{s}\".");
         }
@@ -178,7 +202,7 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>
     [Pure]
     public static ObjectId Parse(string s, Capture capture)
     {
-        if (s is null || capture?.Length is not Sha1CharCount || !TryParse(s.AsSpan(capture.Index, capture.Length), out ObjectId? id))
+        if (s is null || capture?.Length is not Sha1CharCount || !TryParse(s.AsSpan(capture.Index, capture.Length), out ObjectId id))
         {
             throw new FormatException($"Unable to parse object ID \"{s}\".");
         }
@@ -195,9 +219,9 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>
     /// overload <see cref="TryParse(string,int,out ObjectId)"/>.
     /// </remarks>
     /// <param name="s">The string to try parsing from.</param>
-    /// <param name="objectId">The parsed <see cref="ObjectId"/>, or <c>null</c> if parsing was unsuccessful.</param>
+    /// <param name="objectId">The parsed <see cref="ObjectId"/>, or <see langword="default"/> if parsing was unsuccessful.</param>
     /// <returns><c>true</c> if parsing was successful, otherwise <c>false</c>.</returns>
-    public static bool TryParse(string? s, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
+    public static bool TryParse(string? s, out ObjectId objectId)
     {
         if (s is null)
         {
@@ -218,9 +242,9 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>
     /// </remarks>
     /// <param name="s">The string to try parsing from.</param>
     /// <param name="offset">The position within <paramref name="s"/> to start parsing from.</param>
-    /// <param name="objectId">The parsed <see cref="ObjectId"/>, or <c>null</c> if parsing was unsuccessful.</param>
+    /// <param name="objectId">The parsed <see cref="ObjectId"/>, or <see langword="default"/> if parsing was unsuccessful.</param>
     /// <returns><c>true</c> if parsing was successful, otherwise <c>false</c>.</returns>
-    public static bool TryParse(string? s, int offset, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
+    public static bool TryParse(string? s, int offset, out ObjectId objectId)
     {
         if (s is null || s.Length - offset < Sha1CharCount)
         {
@@ -235,13 +259,13 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>
     /// Parses an <see cref="ObjectId"/> from a span of chars.
     /// </summary>
     /// <remarks>
-    /// <para>For parsing to succeed, <paramref name="hex"/> must contain exactly 40 hex characters.</para>
+    /// <para>For parsing to succeed, <paramref name="hex"/> must contain exactly 40 lowercase hex characters.</para>
     /// </remarks>
     /// <param name="hex">The char span to parse.</param>
     /// <param name="objectId">The parsed <see cref="ObjectId"/>.</param>
     /// <returns><c>true</c> if parsing succeeded, otherwise <c>false</c>.</returns>
     [Pure]
-    public static bool TryParse(in ReadOnlySpan<char> hex, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
+    public static bool TryParse(in ReadOnlySpan<char> hex, out ObjectId objectId)
     {
         if (hex.Length != Sha1CharCount)
         {
@@ -270,7 +294,7 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>
     /// <param name="objectId">The parsed <see cref="ObjectId"/>.</param>
     /// <returns><c>true</c> if parsing succeeded, otherwise <c>false</c>.</returns>
     [Pure]
-    public static bool TryParse(in ReadOnlySpan<byte> hex, [NotNullWhen(returnValue: true)] out ObjectId? objectId)
+    public static bool TryParse(in ReadOnlySpan<byte> hex, out ObjectId objectId)
     {
         if (hex.Length != Sha1CharCount)
         {
@@ -311,13 +335,10 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>
 
     #region IComparable<ObjectId>
 
-    public int CompareTo(ObjectId? other)
+    /// <inheritdoc />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int CompareTo(ObjectId other)
     {
-        if (other is null)
-        {
-            return 1;
-        }
-
         return ((ReadOnlySpan<byte>)_data).SequenceCompareTo(other._data);
     }
 
@@ -359,10 +380,10 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>
     #region Equality and hashing
 
     /// <inheritdoc />
-    public bool Equals(ObjectId? other)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool Equals(ObjectId other)
     {
-        return other is not null &&
-               ((ReadOnlySpan<byte>)_data).SequenceEqual(other._data);
+        return ((ReadOnlySpan<byte>)_data).SequenceEqual(other._data);
     }
 
     /// <inheritdoc />
@@ -371,11 +392,11 @@ public sealed class ObjectId : IEquatable<ObjectId>, IComparable<ObjectId>
     /// <inheritdoc />
     public override int GetHashCode()
     {
-        return Unsafe.ReadUnaligned<int>(ref MemoryMarshal.GetReference((ReadOnlySpan<byte>)_data));
+        return Unsafe.ReadUnaligned<int>(ref Unsafe.AsRef(in MemoryMarshal.GetReference((ReadOnlySpan<byte>)_data)));
     }
 
-    public static bool operator ==(ObjectId? left, ObjectId? right) => Equals(left, right);
-    public static bool operator !=(ObjectId? left, ObjectId? right) => !Equals(left, right);
+    public static bool operator ==(ObjectId left, ObjectId right) => left.Equals(right);
+    public static bool operator !=(ObjectId left, ObjectId right) => !left.Equals(right);
 
     #endregion
 }

--- a/src/app/GitUI/CommandsDialogs/FormBrowse.cs
+++ b/src/app/GitUI/CommandsDialogs/FormBrowse.cs
@@ -1827,8 +1827,12 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
         {
             foreach (IGitRef branch in GetBranches())
             {
-                Validates.NotNull(branch.ObjectId);
-                bool isBranchVisible = ((ICheckRefs)RevisionGridControl).Contains(branch.ObjectId);
+                if (!branch.ObjectId.HasValue)
+                {
+                    throw new InvalidOperationException($"Branch '{branch.Name}' has no ObjectId.");
+                }
+
+                bool isBranchVisible = ((ICheckRefs)RevisionGridControl).Contains(branch.ObjectId.Value);
 
                 ToolStripItem toolStripItem = branchSelect.DropDownItems.Add(branch.Name);
                 toolStripItem.ForeColor = isBranchVisible ? branchSelect.ForeColor : Color.Silver.AdaptTextColor();
@@ -2423,13 +2427,13 @@ public sealed partial class FormBrowse : GitModuleForm, IBrowseRepo
         {
             case "gotocommit":
                 Validates.NotNull(e.Data);
-                if (!Module.TryResolvePartialCommitId(e.Data, out ObjectId? commitId) || !RevisionGrid.SetSelectedRevision(commitId))
+                if (!Module.TryResolvePartialCommitId(e.Data, out ObjectId commitId))
                 {
-                    if (commitId is null)
-                    {
-                        return;
-                    }
+                    return;
+                }
 
+                if (!RevisionGrid.SetSelectedRevision(commitId))
+                {
                     // This may occur at various filters, like AppSettings.ShowOnlyFirstParent
                     // will hide other than the first parent.
                     MessageBoxes.RevisionFilteredInGrid(this, commitId);

--- a/src/app/GitUI/CommandsDialogs/FormCheckoutBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCheckoutBranch.cs
@@ -291,14 +291,14 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
                 IGitRef remoteBranchRef = GetRemoteBranchRef(branchName);
                 if (localBranchRef is not null && remoteBranchRef is not null && localBranchRef.ObjectId is not null && remoteBranchRef.ObjectId is not null)
                 {
-                    ObjectId? mergeBaseGuid = Module.GetMergeBase(localBranchRef.ObjectId, remoteBranchRef.ObjectId);
+                    ObjectId? mergeBaseGuid = Module.GetMergeBase(localBranchRef.ObjectId.Value, remoteBranchRef.ObjectId.Value);
                     bool isResetFastForward = localBranchRef.ObjectId == mergeBaseGuid;
 
                     if (!isResetFastForward)
                     {
                         string mergeBaseText = mergeBaseGuid is null
                             ? "merge base"
-                            : mergeBaseGuid.ToShortString();
+                            : mergeBaseGuid.Value.ToShortString();
 
                         string warningMessage = string.Format(_resetNonFastForwardBranch.Text, _localBranchName, mergeBaseText);
 
@@ -484,7 +484,7 @@ public partial class FormCheckoutBranch : GitExtensionsDialog
                 ObjectId? currentCheckout = Module.GetCurrentCheckout();
                 if (currentCheckout is not null)
                 {
-                    aheadBehindInfo = Module.GetCommitCountString(currentCheckout, branch);
+                    aheadBehindInfo = Module.GetCommitCountString(currentCheckout.Value, branch);
                 }
 
                 await this.SwitchToMainThreadAsync();

--- a/src/app/GitUI/CommandsDialogs/FormCheckoutRevision.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCheckoutRevision.cs
@@ -48,7 +48,7 @@ public partial class FormCheckoutRevision : GitExtensionsDialog
                 return;
             }
 
-            string command = Commands.Checkout(selectedObjectId.ToString(), Force.Checked ? LocalChangesAction.Reset : 0);
+            string command = Commands.Checkout(selectedObjectId.Value.ToString(), Force.Checked ? LocalChangesAction.Reset : 0);
             success = FormProcess.ShowDialog(this, UICommands, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
             if (success)
             {

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -1736,8 +1736,8 @@ public sealed partial class FormCommit : GitModuleForm
         ObjectId? headId = Module.RevParse("HEAD");
         if (headId is not null)
         {
-            headRev = new GitRevision(headId);
-            indexRev = new GitRevision(ObjectId.IndexId) { ParentIds = new[] { headId } };
+            headRev = new GitRevision(headId.Value);
+            indexRev = new GitRevision(ObjectId.IndexId) { ParentIds = new ObjectId[] { headId.Value } };
         }
         else
         {

--- a/src/app/GitUI/CommandsDialogs/FormCreateBranch.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCreateBranch.cs
@@ -149,9 +149,20 @@ public sealed partial class FormCreateBranch : GitExtensionsDialog
         {
             ObjectId? originalHash = Module.GetCurrentCheckout();
 
-            ArgumentString command = chkCreateOrphan.Checked
-                ? Commands.CreateOrphan(branchName, objectId)
-                : Commands.Branch(branchName, objectId!.ToString(), chkCheckoutAfterCreate.Checked);
+            ArgumentString command;
+            if (chkCreateOrphan.Checked)
+            {
+                command = Commands.CreateOrphan(branchName, objectId);
+            }
+            else
+            {
+                if (objectId is null)
+                {
+                    throw new InvalidOperationException("objectId must be set for non-orphan branch creation");
+                }
+
+                command = Commands.Branch(branchName, objectId.Value.ToString(), chkCheckoutAfterCreate.Checked);
+            }
 
             bool success = FormProcess.ShowDialog(this, UICommands, arguments: command, Module.WorkingDir, input: null, useDialogSettings: true);
             if (chkCreateOrphan.Checked && success && chkClearOrphan.Checked)

--- a/src/app/GitUI/CommandsDialogs/FormCreateTag.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCreateTag.cs
@@ -87,7 +87,7 @@ public sealed partial class FormCreateTag : GitModuleForm
         }
 
         GitCreateTagArgs createTagArgs = new(textBoxTagName.Text,
-                                                 objectId,
+                                                 objectId.Value,
                                                  GetSelectedOperation(annotate.SelectedIndex),
                                                  tagMessage.Text,
                                                  textBoxGpgKey.Text,

--- a/src/app/GitUI/CommandsDialogs/FormDiff.cs
+++ b/src/app/GitUI/CommandsDialogs/FormDiff.cs
@@ -69,8 +69,8 @@ public partial class FormDiff : GitModuleForm
         }
         else
         {
-            ObjectId? mergeBase = Module.GetMergeBase(firstMergeId, secondMergeId);
-            _mergeBase = mergeBase is not null ? new GitRevision(mergeBase) : null;
+            ObjectId? mergeBase = Module.GetMergeBase(firstMergeId.Value, secondMergeId.Value);
+            _mergeBase = mergeBase is not null ? new GitRevision(mergeBase.Value) : null;
         }
 
         ckCompareToMergeBase.Text = $"{_ckCompareToMergeBase} ({_mergeBase?.ObjectId.ToShortString()})";
@@ -222,7 +222,7 @@ public partial class FormDiff : GitModuleForm
         {
             displayStr = form.BranchName;
             ObjectId? objectId = Module.RevParse(form.BranchName!);
-            revision = objectId is null ? null : new GitRevision(objectId);
+            revision = objectId is null ? null : new GitRevision(objectId.Value);
             PopulateDiffFiles();
         }
     }

--- a/src/app/GitUI/CommandsDialogs/FormFileHistory.cs
+++ b/src/app/GitUI/CommandsDialogs/FormFileHistory.cs
@@ -554,7 +554,7 @@ public sealed partial class FormFileHistory : GitModuleForm, IRevisionGridFileUp
         if (e.Command == "gotocommit")
         {
             Validates.NotNull(e.Data);
-            if (Module.TryResolvePartialCommitId(e.Data, out ObjectId? commitId))
+            if (Module.TryResolvePartialCommitId(e.Data, out ObjectId commitId))
             {
                 if (!RevisionGrid.SetSelectedRevision(commitId))
                 {

--- a/src/app/GitUI/CommandsDialogs/FormMergeSubmodule.cs
+++ b/src/app/GitUI/CommandsDialogs/FormMergeSubmodule.cs
@@ -26,11 +26,11 @@ public sealed partial class FormMergeSubmodule : GitModuleForm
     {
         ConflictData item = ThreadHelper.JoinableTaskFactory.Run(() => Module.GetConflictAsync(_filename));
 
-        tbBase.Text = item.Base.ObjectId?.ToString() ?? _deleted.Text;
-        tbLocal.Text = item.Local.ObjectId?.ToString() ?? _deleted.Text;
-        tbRemote.Text = item.Remote.ObjectId?.ToString() ?? _deleted.Text;
+        tbBase.Text = item.Base.ObjectId.IsZero ? _deleted.Text : item.Base.ObjectId.ToString();
+        tbLocal.Text = item.Local.ObjectId.IsZero ? _deleted.Text : item.Local.ObjectId.ToString();
+        tbRemote.Text = item.Remote.ObjectId.IsZero ? _deleted.Text : item.Remote.ObjectId.ToString();
         tbCurrent.Text = Module.GetSubmodule(_filename).GetCurrentCheckout()?.ToString() ?? "";
-        btCheckoutBranch.Enabled = item.Base.ObjectId is not null && item.Remote.ObjectId is not null;
+        btCheckoutBranch.Enabled = !item.Base.ObjectId.IsZero && !item.Remote.ObjectId.IsZero;
     }
 
     private void btRefresh_Click(object sender, EventArgs e)

--- a/src/app/GitUI/CommandsDialogs/FormRebase.cs
+++ b/src/app/GitUI/CommandsDialogs/FormRebase.cs
@@ -416,7 +416,7 @@ public partial class FormRebase : GitExtensionsDialog
                 {
                     ObjectId? commit1 = UICommands.Module.RevParse(cboBranches.Text);
                     ObjectId? commit2 = UICommands.Module.RevParse("HEAD");
-                    mergeBaseCommitId = UICommands.Module.GetMergeBase(commit1!, commit2!)?.ToString();
+                    mergeBaseCommitId = UICommands.Module.GetMergeBase(commit1!.Value, commit2!.Value)?.ToString();
                 }
                 catch (Exception)
                 {

--- a/src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -775,7 +775,7 @@ public partial class FormResolveConflicts : GitModuleForm
     private string GetLocalSideString() => _inTheMiddleOfRebase ? _theirs.Text : _ours.Text;
 
     private string GetShortHash(ConflictedFileData item)
-        => $"@{(item.ObjectId is null ? _deleted.Text : item.ObjectId.ToShortString())}";
+        => $"@{(item.ObjectId.IsZero ? _deleted.Text : item.ObjectId.ToShortString())}";
 
     private void ConflictedFiles_SelectionChanged(object? sender, EventArgs e)
     {

--- a/src/app/GitUI/CommandsDialogs/FormStash.cs
+++ b/src/app/GitUI/CommandsDialogs/FormStash.cs
@@ -258,10 +258,10 @@ public sealed partial class FormStash : GitModuleForm
             }
             else
             {
-                GitRevision headRev = new(headId);
+                GitRevision headRev = new(headId.Value);
                 GitRevision indexRev = new(ObjectId.IndexId)
                 {
-                    ParentIds = new[] { headId }
+                    ParentIds = new ObjectId[] { headId.Value }
                 };
                 List<GitItemStatus> indexItems = [.. gitItemStatuses.Where(item => item.Staged == StagedStatus.Index)];
                 List<GitItemStatus> workTreeItems = [.. gitItemStatuses.Where(item => item.Staged != StagedStatus.Index)];
@@ -271,14 +271,18 @@ public sealed partial class FormStash : GitModuleForm
         else
         {
             ObjectId? firstId = Module.RevParse(gitStash.Name + "^");
-            GitRevision? firstRev = firstId is null ? null : new(firstId);
+            GitRevision? firstRev = firstId is null ? null : new(firstId.Value);
 
             ObjectId? selectedId = Module.RevParse(gitStash.Name);
-            Validates.NotNull(selectedId);
-            GitRevision secondRev = new(selectedId);
+            if (selectedId is null)
+            {
+                throw new InvalidOperationException("selectedId must not be null");
+            }
+
+            GitRevision secondRev = new(selectedId.Value);
             if (firstId is not null)
             {
-                secondRev.ParentIds = new[] { firstId };
+                secondRev.ParentIds = new ObjectId[] { firstId.Value };
             }
 
             Stashed.SetDiffs(firstRev, secondRev, gitItemStatuses);

--- a/src/app/GitUI/CommandsDialogs/FormVerify.LostObject.cs
+++ b/src/app/GitUI/CommandsDialogs/FormVerify.LostObject.cs
@@ -75,7 +75,7 @@ partial class FormVerify
             // TODO use enum for RawType
             ObjectType = objectType;
             RawType = rawType;
-            ObjectId = objectId ?? throw new ArgumentNullException(nameof(objectId));
+            ObjectId = objectId;
         }
 
         /// <summary>

--- a/src/app/GitUI/CommandsDialogs/FormVerify.cs
+++ b/src/app/GitUI/CommandsDialogs/FormVerify.cs
@@ -545,7 +545,7 @@ public sealed partial class FormVerify : GitModuleForm
 
             if (parent is not null)
             {
-                ClipboardUtil.TrySetText(parent.ToString());
+                ClipboardUtil.TrySetText(parent.Value.ToString());
             }
         }
     }

--- a/src/app/GitUI/CommandsDialogs/RememberFileContextMenuController.cs
+++ b/src/app/GitUI/CommandsDialogs/RememberFileContextMenuController.cs
@@ -110,7 +110,7 @@ public class RememberFileContextMenuController
         {
             // Must be referenced by blob - treeid is mutable.
             // File name presented in difftool will be blob or the other file
-            return getFileBlobHash?.Invoke(name, id)?.ToString();
+            return getFileBlobHash?.Invoke(name, id.Value)?.ToString();
         }
 
         // commit:path

--- a/src/app/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
+++ b/src/app/GitUI/CommandsDialogs/RepoHosting/ViewPullRequestsForm.cs
@@ -389,8 +389,8 @@ public partial class ViewPullRequestsForm : GitModuleForm
         List<GitItemStatus> giss = [];
 
         // baseSha is the sha of the merge to ("master") sha, the commit to be firstId
-        GitRevision? firstRev = ObjectId.TryParse(baseSha, out ObjectId? firstId) ? new GitRevision(firstId) : null;
-        GitRevision? secondRev = ObjectId.TryParse(secondSha, out ObjectId? secondId) ? new GitRevision(secondId) : null;
+        GitRevision? firstRev = ObjectId.TryParse(baseSha, out ObjectId firstId) ? new GitRevision(firstId) : null;
+        GitRevision? secondRev = ObjectId.TryParse(secondSha, out ObjectId secondId) ? new GitRevision(secondId) : null;
         if (secondRev is null)
         {
             MessageBoxes.Show(this, _strUnableUnderstandPatch.Text, TranslatedStrings.Error, MessageBoxButtons.OK, MessageBoxIcon.Error);

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffControl.cs
@@ -339,7 +339,7 @@ public partial class RevisionDiffControl : GitModuleControl, IRevisionGridFileUp
             filterFileInGrid: FilterFileInGrid,
             openInFileTreeTab_AsBlame: OpenInFileTreeTab,
             refreshParent: RequestRefresh,
-            getCurrentRevision: () => _revisionGridInfo?.GetRevision(_revisionGridInfo.CurrentCheckout!)!,
+            getCurrentRevision: () => _revisionGridInfo?.GetRevision(_revisionGridInfo.CurrentCheckout!.Value)!,
             getLineNumber: () => BlameControl.Visible ? BlameControl.CurrentFileLine : DiffText.CurrentFileLine,
             getSelectedText: DiffText.GetSelectedText,
             getSupportLinePatching: () => DiffText.SupportLinePatching);
@@ -392,11 +392,11 @@ public partial class RevisionDiffControl : GitModuleControl, IRevisionGridFileUp
 
         Validates.NotNull(_revisionGridInfo);
 
-        GitRevision revision = _revisionGridInfo.GetRevision(objectId);
+        GitRevision revision = _revisionGridInfo.GetRevision(objectId.Value);
 
         if (revision is null)
         {
-            return objectId.ToShortString();
+            return objectId.Value.ToShortString();
         }
 
         return _revisionGridInfo.DescribeRevision(revision, maxLength);
@@ -451,7 +451,7 @@ public partial class RevisionDiffControl : GitModuleControl, IRevisionGridFileUp
         }
 
         GitRevision? rev = DiffFiles.SelectedItem.SecondRevision.IsArtificial
-            ? _revisionGridInfo!.GetActualRevision(_revisionGridInfo.CurrentCheckout!)
+            ? _revisionGridInfo!.GetActualRevision(_revisionGridInfo.CurrentCheckout!.Value)
             : DiffFiles.SelectedItem.SecondRevision;
         await BlameControl.LoadBlameAsync(rev!, children: null, DiffFiles.SelectedItem.Item.Name, _revisionGridInfo, revisionGridFileUpdate: this,
             controlToMask: null, DiffText.Encoding, line, cancellationTokenSequence: _viewChangesSequence);

--- a/src/app/GitUI/Editor/FileViewer.cs
+++ b/src/app/GitUI/Editor/FileViewer.cs
@@ -722,7 +722,7 @@ public partial class FileViewer : GitModuleControl
                 file.IsSubmodule,
                 getImage: () => ThreadHelper.JoinableTaskFactory.Run(GetImageAsync),
                 getFileText: GetFileText,
-                getSubmoduleText: () => SubmoduleResources.GetSubmoduleText(Module, file.Name.TrimEnd('/'), blobId.ToString()),
+                getSubmoduleText: () => SubmoduleResources.GetSubmoduleText(Module, file.Name.TrimEnd('/'), blobId.Value.ToString()),
                 item: item,
                 line: line,
                 openWithDifftool: openWithDifftool,
@@ -736,14 +736,14 @@ public partial class FileViewer : GitModuleControl
                 || (!file.Name.EndsWith(".diff", StringComparison.OrdinalIgnoreCase)
                    && !file.Name.EndsWith(".patch", StringComparison.OrdinalIgnoreCase));
             FilePreamble = [];
-            return Module.GetFileText(blobId, Encoding, stripAnsiEscapeCodes) ?? "";
+            return Module.GetFileText(blobId.Value, Encoding, stripAnsiEscapeCodes) ?? "";
         }
 
         async Task<Image?> GetImageAsync()
         {
             try
             {
-                using MemoryStream? stream = await Module.GetFileStreamAsync(blobId.ToString(), cancellationToken: default);
+                using MemoryStream? stream = await Module.GetFileStreamAsync(blobId.Value.ToString(), cancellationToken: default);
                 if (stream is not null)
                 {
                     return CreateImage(file.Name, stream);

--- a/src/app/GitUI/GitUICommands.cs
+++ b/src/app/GitUI/GitUICommands.cs
@@ -1749,7 +1749,7 @@ public sealed class GitUICommands : IGitUICommands
             firstId = null;
             foreach (string part in arg.LazySplit(','))
             {
-                if (!module.TryResolvePartialCommitId(part, out ObjectId? objectId))
+                if (!module.TryResolvePartialCommitId(part, out ObjectId objectId))
                 {
                     return false;
                 }
@@ -1860,7 +1860,7 @@ public sealed class GitUICommands : IGitUICommands
         GitRevision? revision = null;
         if (args.Count > 3)
         {
-            if (!ObjectId.TryParse(args[3], out ObjectId? objectId))
+            if (!ObjectId.TryParse(args[3], out ObjectId objectId))
             {
                 return false;
             }

--- a/src/app/GitUI/GitUIExtensions.cs
+++ b/src/app/GitUI/GitUIExtensions.cs
@@ -76,7 +76,7 @@ public static partial class GitUIExtensions
             await fileViewer.ViewTextAsync(fileName: null, $"git range-diff {range} -- {additionalCommandInfo}", cancellationToken: cancellationToken);
 
             ExecutionResult result = await fileViewer.Module.GetRangeDiffAsync(
-                    firstId!,
+                    firstId!.Value,
                     item.SecondRevision.ObjectId,
                     item.BaseA,
                     item.BaseB,
@@ -174,7 +174,7 @@ public static partial class GitUIExtensions
 
         if (AppSettings.DiffDisplayAppearance.Value == GitCommands.Settings.DiffDisplayAppearance.Difftastic && fileViewer.IsDifftasticEnabled.Value)
         {
-            bool isTracked = item.Item.IsTracked || (item.Item.TreeGuid is not null && item.SecondRevision.ObjectId is not null);
+            bool isTracked = item.Item.IsTracked || (item.Item.TreeGuid is not null && !item.SecondRevision.ObjectId.IsZero);
             (ArgumentString diffArgs, string extraCacheKey) = fileViewer.GetDifftasticArguments();
 
             // set file name as null to not change the restore lineno
@@ -200,7 +200,7 @@ public static partial class GitUIExtensions
         }
 
         // diff of text file
-        string selectedPatch = (await GetSelectedPatchAsync(fileViewer, firstId!, item.SecondRevision.ObjectId, item.Item, cancellationToken))
+        string selectedPatch = (await GetSelectedPatchAsync(fileViewer, firstId!.Value, item.SecondRevision.ObjectId, item.Item, cancellationToken))
             ?? defaultText;
 
         await fileViewer.ViewPatchAsync(item, text: selectedPatch, line: line, openWithDifftool: openWithDiffTool, cancellationToken: cancellationToken);

--- a/src/app/GitUI/LeftPanel/BaseRevisionNode.cs
+++ b/src/app/GitUI/LeftPanel/BaseRevisionNode.cs
@@ -118,7 +118,7 @@ internal abstract class BaseRevisionNode : Node
 
         TreeViewNode.TreeView?.BeginInvoke(() =>
         {
-            UICommands.BrowseRepo?.GoToRef(ObjectId.ToString(), showNoRevisionMsg: true, toggleSelection: Control.ModifierKeys.HasFlag(Keys.Control));
+            UICommands.BrowseRepo?.GoToRef(ObjectId.Value.ToString(), showNoRevisionMsg: true, toggleSelection: Control.ModifierKeys.HasFlag(Keys.Control));
             TreeViewNode.TreeView?.Focus();
         });
     }

--- a/src/app/GitUI/LeftPanel/BaseRevisionTree.cs
+++ b/src/app/GitUI/LeftPanel/BaseRevisionTree.cs
@@ -59,7 +59,7 @@ internal abstract class BaseRevisionTree : Tree
                     continue;
                 }
 
-                bool isVisible = _refsSource.Contains(node.ObjectId);
+                bool isVisible = _refsSource.Contains(node.ObjectId.Value);
                 if (node.Visible != isVisible)
                 {
                     node.Visible = isVisible;

--- a/src/app/GitUI/LeftPanel/LocalBranchTree.cs
+++ b/src/app/GitUI/LeftPanel/LocalBranchTree.cs
@@ -59,9 +59,12 @@ internal sealed class LocalBranchTree : BaseRefTree
         {
             token.ThrowIfCancellationRequested();
 
-            Validates.NotNull(branch.ObjectId);
+            if (!branch.ObjectId.HasValue)
+            {
+                continue;
+            }
 
-            LocalBranchNode localBranchNode = new(this, branch.ObjectId, branch.Name, branch.Name == currentBranch, visible: true);
+            LocalBranchNode localBranchNode = new(this, branch.ObjectId.Value, branch.Name, branch.Name == currentBranch, visible: true);
 
             if (aheadBehindData?.TryGetValue(localBranchNode.FullPath, out AheadBehindData aheadBehind) is true)
             {

--- a/src/app/GitUI/LeftPanel/RemoteBranchTree.cs
+++ b/src/app/GitUI/LeftPanel/RemoteBranchTree.cs
@@ -35,12 +35,15 @@ internal sealed class RemoteBranchTree : BaseRefTree
         {
             token.ThrowIfCancellationRequested();
 
-            Validates.NotNull(branch.ObjectId);
+            if (!branch.ObjectId.HasValue)
+            {
+                continue;
+            }
 
             string remoteName = branch.Name.SubstringUntil('/');
             if (remoteByName.TryGetValue(remoteName, out Remote remote))
             {
-                RemoteBranchNode remoteBranchNode = new(this, branch.ObjectId, branch.Name, visible: true);
+                RemoteBranchNode remoteBranchNode = new(this, branch.ObjectId.Value, branch.Name, visible: true);
                 if (aheadBehindData?.TryGetValue(branch.CompleteName, out AheadBehindData aheadBehind) is true)
                 {
                     remoteBranchNode.UpdateAheadBehind(aheadBehind.ToDisplay(), $"{GitRefName.RefsHeadsPrefix}{aheadBehind.Branch}");

--- a/src/app/GitUI/UserControls/BlameControl.cs
+++ b/src/app/GitUI/UserControls/BlameControl.cs
@@ -558,9 +558,9 @@ public sealed partial class BlameControl : GitModuleControl
     private void contextMenu_Opened(object sender, EventArgs e)
     {
         Validates.NotNull(_fileName);
-        Validates.NotNull(_blameId);
+        DebugHelpers.Assert(_blameId.HasValue, "_blameId must have a value");
 
-        contextMenu.Tag = new GitBlameContext(_fileName, _lineIndex, GetBlameLine(), _blameId);
+        contextMenu.Tag = new GitBlameContext(_fileName, _lineIndex, GetBlameLine(), _blameId.Value);
 
         if (!TryGetRevision(GetBlameCommit(), out (GitRevision? SelectedRevision, string? Filename) blameinfo))
         {
@@ -589,7 +589,7 @@ public sealed partial class BlameControl : GitModuleControl
         return;
 
         bool RevisionHasParent(GitRevision? revision)
-            => (revision?.HasParent is true) && (_revisionGridInfo?.GetRevision(revision!.FirstParentId!) is not null);
+            => (revision?.HasParent is true) && (_revisionGridInfo?.GetRevision(revision!.FirstParentId!.Value) is not null);
     }
 
     private GitBlameCommit? GetBlameCommit()
@@ -674,7 +674,7 @@ public sealed partial class BlameControl : GitModuleControl
         int originalLineNumberOfPreviousBlame = _gitBlameParser.GetOriginalLineInPreviousCommit(selectedRevision!, blameInfo.Filename!, finalLineNumberOfPreviousBlame);
 
         GitBlameLine blameLine = new(_lastBlameLine.Commit, finalLineNumberOfPreviousBlame, originalLineNumberOfPreviousBlame, "Dummy Git blame line used only to store the good 'originLineNumber' value to display and select it");
-        BlameRevision(selectedRevision!.FirstParentId!, blameInfo.Filename!, blameLine);
+        BlameRevision(selectedRevision!.FirstParentId!.Value, blameInfo.Filename!, blameLine);
     }
 
     /// <summary>

--- a/src/app/GitUI/UserControls/BranchSelector.cs
+++ b/src/app/GitUI/UserControls/BranchSelector.cs
@@ -125,7 +125,7 @@ public partial class BranchSelector : GitModuleControl
 
             ThreadHelper.FileAndForget(async () =>
             {
-                string text = Module.GetCommitCountString(currentCheckout, branchName);
+                string text = Module.GetCommitCountString(currentCheckout.Value, branchName);
                 await this.SwitchToMainThreadAsync();
                 lbChanges.Text = text;
             });

--- a/src/app/GitUI/UserControls/CommitPickerSmallControl.cs
+++ b/src/app/GitUI/UserControls/CommitPickerSmallControl.cs
@@ -50,7 +50,7 @@ public partial class CommitPickerSmallControl : GitModuleControl
         }
         else
         {
-            textBoxCommitHash.Text = SelectedObjectId.ToShortString();
+            textBoxCommitHash.Text = SelectedObjectId.Value.ToShortString();
             ThreadHelper.FileAndForget(async () =>
                 {
                     ObjectId? currentCheckout = Module.GetCurrentCheckout();
@@ -60,8 +60,8 @@ public partial class CommitPickerSmallControl : GitModuleControl
                         return;
                     }
 
-                    string toRef = SelectedObjectId.IsArtificial ? "HEAD" : SelectedObjectId.ToString();
-                    string text = Module.GetCommitCountString(currentCheckout, toRef);
+                    string toRef = SelectedObjectId.Value.IsArtificial ? "HEAD" : SelectedObjectId.Value.ToString();
+                    string text = Module.GetCommitCountString(currentCheckout.Value, toRef);
 
                     await this.SwitchToMainThreadAsync();
 

--- a/src/app/GitUI/UserControls/FileStatusDiffCalculator.cs
+++ b/src/app/GitUI/UserControls/FileStatusDiffCalculator.cs
@@ -122,7 +122,7 @@ public sealed partial class FileStatusDiffCalculator
                         ? module.GetDiffFilesWithSubmodulesStatus(firstId: null, selectedRev.ObjectId, parentToSecond: null, cancellationToken: cancellationToken)
 
                         // No parent for the initial commit, show files and explicitly set IsNew
-                        : module.GetTreeFiles(selectedRev.TreeGuid, full: true, cancellationToken)
+                        : module.GetTreeFiles(selectedRev.TreeGuid.Value, full: true, cancellationToken)
                             .Select(i =>
                             {
                                 i.IsNew = true;
@@ -168,8 +168,8 @@ public sealed partial class FileStatusDiffCalculator
         }
 
         // Get merge base commit, use HEAD for artificial
-        ObjectId? firstRevHead = GetRevisionOrHead(firstRev, headId!);
-        ObjectId? selectedRevHead = GetRevisionOrHead(selectedRev, headId!);
+        ObjectId firstRevHead = GetRevisionOrHead(firstRev, headId!.Value);
+        ObjectId selectedRevHead = GetRevisionOrHead(selectedRev, headId!.Value);
         ObjectId? baseRevId = null;
         if (revisions.Count != 3)
         {
@@ -207,10 +207,10 @@ public sealed partial class FileStatusDiffCalculator
             // Four: Two ranges must be selected
             else
             {
-                baseA = GetMergeBase(GetRevisionOrHead(revisions[3], headId!), firstRevHead);
+                baseA = GetMergeBase(GetRevisionOrHead(revisions[3], headId!.Value), firstRevHead);
                 if (baseA == revisions[3].ObjectId)
                 {
-                    baseB = GetMergeBase(GetRevisionOrHead(revisions[1], headId!), selectedRevHead);
+                    baseB = GetMergeBase(GetRevisionOrHead(revisions[1], headId!.Value), selectedRevHead);
                     if (baseB != revisions[1].ObjectId)
                     {
                         baseB = null;
@@ -270,7 +270,7 @@ public sealed partial class FileStatusDiffCalculator
                 : DiffBranchStatus.UnequalChange;
         }
 
-        GitRevision revBase = new(baseRevId);
+        GitRevision revBase = new(baseRevId.Value);
         fileStatusDescs.Add(new FileStatusWithDescription(
             firstRev: revBase,
             secondRev: selectedRev,
@@ -296,7 +296,7 @@ public sealed partial class FileStatusDiffCalculator
 
         // first and selected has a common merge base and count must be available
         // Only a printout, so no Validates
-        string desc = $"{TranslatedStrings.DiffRange} {baseToFirstCount ?? -1}↓ {baseToSecondCount ?? -1}↑ BASE {GetDescriptionForRevision(baseRevId)}";
+        string desc = $"{TranslatedStrings.DiffRange} {baseToFirstCount ?? -1}↓ {baseToSecondCount ?? -1}↑ BASE {GetDescriptionForRevision(baseRevId.Value)}";
         fileStatusDescs.Insert(index: 1, new FileStatusWithDescription(
             firstRev: firstRev,
             secondRev: selectedRev,
@@ -313,7 +313,7 @@ public sealed partial class FileStatusDiffCalculator
                 return null;
             }
 
-            return module.GetMergeBase(a, b);
+            return module.GetMergeBase(a.Value, b.Value);
         }
 
         static ObjectId GetRevisionOrHead(GitRevision rev, ObjectId headId)

--- a/src/app/GitUI/UserControls/FileStatusList.ContextMenu.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.ContextMenu.cs
@@ -1098,7 +1098,7 @@ partial class FileStatusList
 
             string fileName = PathUtil.GetFileName(item.Item.Name);
             fileName = (Path.GetTempPath() + fileName).ToNativePath();
-            await Module.SaveBlobAsAsync(fileName, blob.ToString());
+            await Module.SaveBlobAsAsync(fileName, blob.Value.ToString());
 
             onSaved(fileName);
         });

--- a/src/app/GitUI/UserControls/FileStatusList.cs
+++ b/src/app/GitUI/UserControls/FileStatusList.cs
@@ -317,7 +317,7 @@ public sealed partial class FileStatusList : GitModuleControl
         }
     }
 
-    public void Bind(Action refreshArtificial, bool canAutoRefresh = false, Func<ObjectId?, string>? describeRevision = null, Func<GitRevision, GitRevision>? getActualRevision = null, bool isFileTreeMode = false)
+    public void Bind(Action refreshArtificial, bool canAutoRefresh = false, Func<ObjectId, string>? describeRevision = null, Func<GitRevision, GitRevision>? getActualRevision = null, bool isFileTreeMode = false)
     {
         btnRefresh.Click += (s, e) => refreshArtificial();
         btnRefresh.Visible = true;
@@ -433,7 +433,7 @@ public sealed partial class FileStatusList : GitModuleControl
 
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     [Browsable(false)]
-    public Func<ObjectId?, string>? DescribeRevision { get; set; }
+    public Func<ObjectId, string>? DescribeRevision { get; set; }
 
     public bool FilterFilesByNameRegexFocused => cboFilterComboBox.Focused;
     public bool FindInCommitFilesGitGrepActive => !string.IsNullOrEmpty(cboFindInCommitFilesGitGrep.Text);
@@ -934,11 +934,11 @@ public sealed partial class FileStatusList : GitModuleControl
     }
 
     private string? GetDescriptionForRevision(ObjectId? objectId)
-        => DescribeRevision is not null ? DescribeRevision(objectId)
+        => DescribeRevision is not null && objectId is not null ? DescribeRevision(objectId.Value)
             : objectId is null ? ""
             : objectId == ObjectId.WorkTreeId ? ResourceManager.TranslatedStrings.Workspace
             : objectId == ObjectId.IndexId ? ResourceManager.TranslatedStrings.Index
-            : objectId.ToShortString();
+            : objectId.Value.ToShortString();
 
     public void SetNoFilesText(string text)
     {

--- a/src/app/GitUI/UserControls/PatchGrid.cs
+++ b/src/app/GitUI/UserControls/PatchGrid.cs
@@ -136,7 +136,7 @@ public partial class PatchGrid : GitModuleControl
             }
             else
             {
-                if (!ObjectId.TryParse(parts[1], out ObjectId? parsedId))
+                if (!ObjectId.TryParse(parts[1], out ObjectId parsedId))
                 {
                     Trace.Write($"PatchGrid: GetInteractiveRebasePatchFiles: Unable to parse commit hash '{parts[1]}' from '{todoCommits}'. Skipping this entry.");
                     continue;
@@ -399,10 +399,10 @@ public partial class PatchGrid : GitModuleControl
 
         PatchFile? patchFile = (PatchFile?)Patches.SelectedRows[0].DataBoundItem;
 
-        if (patchFile?.ObjectId?.IsArtificial is false)
+        if (patchFile?.ObjectId is { IsArtificial: false } patchObjectId)
         {
             // Normal commit selected
-            UICommands.StartFormCommitDiff(patchFile.ObjectId);
+            UICommands.StartFormCommitDiff(patchObjectId);
             return;
         }
 

--- a/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Columns/MessageColumnProvider.cs
@@ -104,7 +104,7 @@ internal sealed class MessageColumnProvider : ColumnProvider
             // Draw super project references (for submodules)
             DrawSuperprojectInfo(e, spi, revision, style, messageBounds, ref offset);
 
-            if (spi.Refs is not null && revision.ObjectId is not null &&
+            if (spi.Refs is not null && !revision.ObjectId.IsZero &&
                 spi.Refs.TryGetValue(revision.ObjectId, out IReadOnlyList<IGitRef>? refs))
             {
                 superprojectRefs.AddRange(refs);

--- a/src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/Graph/RevisionGraph.cs
@@ -111,7 +111,7 @@ public class RevisionGraph : IRevisionGraphRowProvider
     public int Count { get; private set; }
 
     public bool OnlyFirstParent { get; set; }
-    public ObjectId HeadId { get; set; } = null!;
+    public ObjectId HeadId { get; set; }
 
     /// <summary>
     /// Checks whether the given hash is present in the graph.

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionDataGridView.cs
@@ -840,7 +840,7 @@ public sealed partial class RevisionDataGridView : DataGridView
 
     public int? TryGetRevisionIndex(ObjectId? objectId)
     {
-        return objectId is not null && _revisionGraph.TryGetRowIndex(objectId, out int index) ? index : null;
+        return objectId is not null && _revisionGraph.TryGetRowIndex(objectId.Value, out int index) ? index : null;
     }
 
     public IReadOnlyList<ObjectId> GetRevisionChildren(ObjectId objectId)

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridControl.cs
@@ -258,7 +258,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         {
             if (!SetSelectedRevision(commitId))
             {
-                MessageBoxes.RevisionFilteredInGrid(this, commitId!);
+                MessageBoxes.RevisionFilteredInGrid(this, commitId!.Value);
             }
         });
         _authorHighlighting = new AuthorRevisionHighlighting();
@@ -646,11 +646,11 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             return false;
         }
 
-        Validates.NotNull(commitId);
+        DebugHelpers.Assert(commitId.HasValue, "commitId must have a value");
         SetSelectedIndex(_gridView, index, toggleSelection);
         if (updateNavigationHistory)
         {
-            _navigationHistory.Push(commitId);
+            _navigationHistory.Push(commitId.Value);
         }
 
         return true;
@@ -1045,7 +1045,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                     }
                     else
                     {
-                        currentlySelectedObjectIds = new List<ObjectId> { CurrentCheckout };
+                        currentlySelectedObjectIds = new List<ObjectId> { CurrentCheckout.Value };
                     }
                 }
 
@@ -1053,14 +1053,15 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                 refsByObjectId = (showStashes
                     ? getUnfilteredRefs.Value.Where(r => r.CompleteName != GitRefName.RefsStashPrefix)
                     : getUnfilteredRefs.Value)
-                    .ToLookup(gitRef => gitRef.ObjectId)!;
+                    .Where(gitRef => gitRef.ObjectId.HasValue)
+                    .ToLookup(gitRef => gitRef.ObjectId!.Value);
                 cancellationToken.ThrowIfCancellationRequested();
                 ResetNavigationHistory();
                 UpdateSelectedRef(capturedModule, getUnfilteredRefs.Value, headRef.Value);
                 _gridView.ToBeSelectedObjectIds = GetToBeSelectedRevisions(CurrentCheckout, currentlySelectedObjectIds)!;
 
                 _gridView._revisionGraph.OnlyFirstParent = _filterInfo.ShowOnlyFirstParent;
-                _gridView._revisionGraph.HeadId = CurrentCheckout!;
+                _gridView._revisionGraph.HeadId = CurrentCheckout ?? default;
 
                 // Allow add revisions to the grid
                 semaphoreUpdateGrid.Release();
@@ -1101,8 +1102,9 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                             return;
                         }
 
-                        // "stash" commits to insert (before regular commits)
-                        stashesByParentId = getStashRevs.Value.ToLookup(r => r.FirstParentId!);
+                        stashesByParentId = getStashRevs.Value
+                            .Where(r => r.FirstParentId.HasValue)
+                            .ToLookup(r => r.FirstParentId!.Value);
 
                         // "untracked" commits to insert (parent to "stash" commits)
                         Dictionary<ObjectId, ObjectId> untrackedIdByStashId = getStashRevs.Value
@@ -1122,8 +1124,8 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                         foreach (GitRevision stash in getStashRevs.Value)
                         {
                             stash.ParentIds = untrackedByStashId!.ContainsKey(stash.ObjectId)
-                                ? [stash.FirstParentId!, stash.ParentIds![2]]
-                                : [stash.FirstParentId!];
+                                ? [stash.FirstParentId!.Value, stash.ParentIds![2]]
+                                : [stash.FirstParentId!.Value];
                         }
                     }
                     catch
@@ -1393,7 +1395,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                 CommitUnixTime = 0,
                 CommitterEmail = userEmail,
                 Subject = ResourceManager.TranslatedStrings.Index,
-                ParentIds = CurrentCheckout is null ? null : new[] { CurrentCheckout },
+                ParentIds = CurrentCheckout is null ? null : new ObjectId[] { CurrentCheckout.Value },
                 Notes = ""
             };
 
@@ -1465,7 +1467,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                     if (CurrentCheckout is not null)
                     {
                         // Not found, so search for its parents
-                        headParents = TryGetParents(Module, _filterInfo, CurrentCheckout).ToList();
+                        headParents = TryGetParents(Module, _filterInfo, CurrentCheckout.Value).ToList();
                     }
 
                     // HEAD where to insert the artificial was not found
@@ -1550,7 +1552,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             {
                 spi.Refs = refs
                     .Where(a => a.Value is not null && a.Value.ObjectId is not null)
-                    .GroupBy(a => a.Value!.ObjectId!)
+                    .GroupBy(a => a.Value!.ObjectId!.Value)
                     .ToDictionary(gr => gr.Key, gr => gr.Select(a => a.Key).AsReadOnlyList());
             }
 
@@ -1573,12 +1575,12 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                 IReadOnlyList<ObjectId>? toBeSelectedObjectIds;
                 if (FirstId is not null)
                 {
-                    toBeSelectedObjectIds = new ObjectId[] { FirstId, SelectedId };
+                    toBeSelectedObjectIds = new ObjectId[] { FirstId.Value, SelectedId.Value };
                     FirstId = null;
                 }
                 else
                 {
-                    toBeSelectedObjectIds = new ObjectId[] { SelectedId };
+                    toBeSelectedObjectIds = new ObjectId[] { SelectedId.Value };
                 }
 
                 SelectedId = null;
@@ -1589,7 +1591,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                 ? currentlySelectedObjectIds
                 : currentCheckout is null
                     ? []
-                    : new ObjectId[] { currentCheckout };
+                    : new ObjectId[] { currentCheckout.Value };
         }
 
         static IEnumerable<ObjectId> TryGetParents(IGitModule module, FilterInfo filterInfo, ObjectId objectId)
@@ -1605,7 +1607,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             ExecutionResult result = module.GitExecutable.Execute(args, throwOnErrorExit: false);
             foreach (string line in result.StandardOutput.LazySplit('\n'))
             {
-                if (ObjectId.TryParse(line, out ObjectId? parentId))
+                if (ObjectId.TryParse(line, out ObjectId parentId))
                 {
                     yield return parentId;
                 }
@@ -1626,7 +1628,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             return null;
         }
 
-        if (FilePathByObjectId?.TryGetValue(objectId, out string? fileName) is true)
+        if (FilePathByObjectId?.TryGetValue(objectId.Value, out string? fileName) is true)
         {
             return fileName;
         }
@@ -1639,7 +1641,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             "--follow",
             "--diff-merges=separate",
             FindRenamesAndCopiesOpts(),
-            objectId.ToString(),
+            objectId.Value.ToString(),
             "--max-count=1",
             "--",
             path.QuoteIfNotQuotedAndNE(),
@@ -1671,8 +1673,12 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
             if (line.StartsWith(_objectIdPrefix))
             {
-                if (line.Length < ObjectId.Sha1CharCount + _objectIdPrefix.Length
-                    || !ObjectId.TryParse(line, offset: _objectIdPrefix.Length, out currentObjectId))
+                if (line.Length >= ObjectId.Sha1CharCount + _objectIdPrefix.Length
+                    && ObjectId.TryParse(line, offset: _objectIdPrefix.Length, out ObjectId parsedId))
+                {
+                    currentObjectId = parsedId;
+                }
+                else
                 {
                     // Parse error, ignore
                     currentObjectId = null;
@@ -1689,7 +1695,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
             // Add only the first file to the dictionary
             cancellationToken.ThrowIfCancellationRequested();
-            FilePathByObjectId?.TryAdd(currentObjectId, line);
+            FilePathByObjectId?.TryAdd(currentObjectId.Value, line);
 
             yield return line;
         }
@@ -2834,15 +2840,18 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             for (int i = 0; i < 3; ++i)
             {
                 idToSelect = GetNextIdToSelect(idToSelect);
-                if (idToSelect is null
-
-                    // WorkTree and Index are skipped if and only if we do retrieve the ChangeCount info (only for artificial) and HasChanges returns false.
-                    || (AppSettings.ShowGitStatusForArtificialCommits && (GetChangeCount(idToSelect)?.HasChanges is false)))
+                if (idToSelect is null)
                 {
                     continue;
                 }
 
-                if (idToSelect == CurrentCheckout && AppSettings.RevisionGraphShowArtificialCommits && _gridView.GetRevision(idToSelect) is null)
+                // WorkTree and Index are skipped if and only if we do retrieve the ChangeCount info (only for artificial) and HasChanges returns false.
+                if (AppSettings.ShowGitStatusForArtificialCommits && (GetChangeCount(idToSelect.Value)?.HasChanges is false))
+                {
+                    continue;
+                }
+
+                if (idToSelect == CurrentCheckout && AppSettings.RevisionGraphShowArtificialCommits && _gridView.GetRevision(idToSelect.Value) is null)
                 {
                     // HEAD is not in revision grid (filtered)
                     return ObjectId.WorkTreeId;
@@ -2994,12 +3003,12 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         GitRevision revision = revisions[^1];
         while (revision!.IsArtificial)
         {
-            revision = GetRevision(revision.FirstParentId!)!;
+            revision = GetRevision(revision.FirstParentId!.Value)!;
         }
 
         do
         {
-            GitRevision? prevRev = GetRevision(revision.FirstParentId!);
+            GitRevision? prevRev = GetRevision(revision.FirstParentId!.Value);
             if (prevRev == null)
             {
                 break;
@@ -3098,7 +3107,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
         {
             if (!SetSelectedRevision(commitId, toggleSelection) && showNoRevisionMsg)
             {
-                MessageBoxes.RevisionFilteredInGrid(this, commitId);
+                MessageBoxes.RevisionFilteredInGrid(this, commitId.Value);
             }
         }
         else if (showNoRevisionMsg)
@@ -3158,7 +3167,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
                 return;
             }
 
-            ShowFormDiff(baseCommit, headCommit.ObjectId, form.BranchName, headCommit.Subject);
+            ShowFormDiff(baseCommit.Value, headCommit.ObjectId, form.BranchName, headCommit.Subject);
         }
     }
 
@@ -3176,7 +3185,7 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             return;
         }
 
-        ShowFormDiff(baseCommit.ObjectId, CurrentCheckout, baseCommit.Subject, CurrentBranch.Value);
+        ShowFormDiff(baseCommit.ObjectId, CurrentCheckout.Value, baseCommit.Subject, CurrentBranch.Value);
     }
 
     private void selectAsBaseToolStripMenuItem_Click(object sender, EventArgs e)
@@ -3225,8 +3234,8 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
 
         if (selected is not null && firstId is not null)
         {
-            string firstSubject = GetRevision(firstId)?.Subject ?? "";
-            ShowFormDiff(firstId, selected.ObjectId, firstSubject, selected.Subject);
+            string firstSubject = GetRevision(firstId.Value)?.Subject ?? "";
+            ShowFormDiff(firstId.Value, selected.ObjectId, firstSubject, selected.Subject);
         }
         else
         {
@@ -3404,7 +3413,10 @@ public sealed partial class RevisionGridControl : GitModuleControl, ICheckRefs, 
             case Command.SelectCurrentRevision:
                 if (!SetSelectedRevision(CurrentCheckout))
                 {
-                    MessageBoxes.RevisionFilteredInGrid(this, CurrentCheckout!);
+                    if (CurrentCheckout.HasValue)
+                    {
+                        MessageBoxes.RevisionFilteredInGrid(this, CurrentCheckout.Value);
+                    }
                 }
 
                 break;

--- a/src/app/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/RevisionGridMenuCommands.cs
@@ -529,7 +529,7 @@ internal class RevisionGridMenuCommands : MenuCommandsBase
         {
             if (!_revisionGrid.SetSelectedRevision(commitId))
             {
-                MessageBoxes.RevisionFilteredInGrid(_revisionGrid, commitId);
+                MessageBoxes.RevisionFilteredInGrid(_revisionGrid, commitId.Value);
             }
         }
         else

--- a/src/app/ResourceManager/CommitDataRenders/CommitDataBodyRenderer.cs
+++ b/src/app/ResourceManager/CommitDataRenders/CommitDataBodyRenderer.cs
@@ -56,7 +56,7 @@ public sealed class CommitDataBodyRenderer : ICommitDataBodyRenderer
             return hash;
         }
 
-        if (!module.TryResolvePartialCommitId(hash, out ObjectId? fullHash))
+        if (!module.TryResolvePartialCommitId(hash, out ObjectId fullHash))
         {
             return hash;
         }

--- a/src/plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
+++ b/src/plugins/BuildServerIntegration/AppVeyorIntegration/AppVeyorAdapter.cs
@@ -137,11 +137,15 @@ internal sealed class AppVeyorAdapter : IBuildServerAdapter
             List<AppVeyorBuildInfo> filteredBuilds = [];
             foreach (AppVeyorBuildInfo build in allBuilds.OrderByDescending(b => b.StartDate))
             {
-                Validates.NotNull(build.CommitId);
-                if (!_fetchBuilds.Contains(build.CommitId))
+                if (build.CommitId is not { } commitId)
+                {
+                    continue;
+                }
+
+                if (!_fetchBuilds.Contains(commitId))
                 {
                     filteredBuilds.Add(build);
-                    _fetchBuilds.Add(build.CommitId);
+                    _fetchBuilds.Add(commitId);
                 }
             }
 
@@ -195,7 +199,7 @@ internal sealed class AppVeyorAdapter : IBuildServerAdapter
             {
                 string? commitHash = GetNodeString(b["pullRequestHeadCommitId"])
                     ?? GetNodeString(b["commitId"]);
-                if (!ObjectId.TryParse(commitHash, out ObjectId? objectId) || !_isCommitInRevisionGrid(objectId))
+                if (!ObjectId.TryParse(commitHash, out ObjectId objectId) || !_isCommitInRevisionGrid(objectId))
                 {
                     continue;
                 }
@@ -217,7 +221,7 @@ internal sealed class AppVeyorAdapter : IBuildServerAdapter
                     BuildId = GetNodeString(b["buildId"]),
                     Branch = GetNodeString(b["branch"]),
                     CommitId = objectId,
-                    CommitHashList = new[] { objectId },
+                    CommitHashList = [objectId],
                     Status = status,
                     StartDate = b["started"]?.GetValue<DateTime>() ?? DateTime.MinValue,
                     BaseWebUrl = baseWebUrl,

--- a/tests/app/UnitTests/GitCommands.Tests/ArgumentBuilderExtensionsTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/ArgumentBuilderExtensionsTests.cs
@@ -239,7 +239,7 @@ public sealed class ArgumentBuilderExtensionsTests
     }
 
     [TestCase(null)]
-    public void Handle_null_objectid(ObjectId id)
+    public void Handle_null_objectid(ObjectId? id)
     {
         ArgumentBuilder args =
         [

--- a/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.CreateTag.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/CommandsTests.CreateTag.cs
@@ -25,8 +25,7 @@ partial class CommandsTests
     [Test]
     public void Validate_should_throw_if_tag_revision_invalid()
     {
-        GitCreateTagArgs args = new(TagName, null!);
-        ClassicAssert.Throws<ArgumentException>(() => Commands.CreateTag(args, TagMessageFile, PathUtil.ToPosixPath));
+        ClassicAssert.Throws<ArgumentException>(() => new GitCreateTagArgs(TagName, default));
     }
 
     [TestCase(null)]

--- a/tests/app/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/ObjectIdTests.cs
@@ -23,8 +23,8 @@ public sealed partial class ObjectIdTests
     [TestCase("0123456789abcdef0123456789abcdef01234567")]
     public void TryParse_handles_valid_hashes(string sha1)
     {
-        ClassicAssert.True(ObjectId.TryParse(sha1, out ObjectId? id));
-        ClassicAssert.AreEqual(sha1.ToLower(), id!.ToString());
+        ClassicAssert.True(ObjectId.TryParse(sha1, out ObjectId id));
+        ClassicAssert.AreEqual(sha1.ToLower(), id.ToString());
     }
 
     [TestCase("00000000000000000000000000000000000000")]
@@ -46,10 +46,10 @@ public sealed partial class ObjectIdTests
     [TestCase("__0102030405060708091011121314151617181920__", 2)]
     public void TryParse_with_offset_handles_valid_hashes(string sha1, int offset)
     {
-        ClassicAssert.True(ObjectId.TryParse(sha1, offset, out ObjectId? id));
+        ClassicAssert.True(ObjectId.TryParse(sha1, offset, out ObjectId id));
         ClassicAssert.AreEqual(
             sha1.Substring(offset, 40),
-            id!.ToString());
+            id.ToString());
     }
 
     [TestCase("0000000000000000000000000000000000000000")]
@@ -250,7 +250,7 @@ public sealed partial class ObjectIdTests
     {
         byte[] sourceBytes = Encoding.ASCII.GetBytes(source);
 
-        ClassicAssert.AreEqual(expected is not null, ObjectId.TryParse(sourceBytes.AsSpan(offset, 40), out ObjectId? id));
+        ClassicAssert.AreEqual(expected is not null, ObjectId.TryParse(sourceBytes.AsSpan(offset, 40), out ObjectId id));
 
         if (expected is not null)
         {
@@ -262,16 +262,16 @@ public sealed partial class ObjectIdTests
     public void TryParse_bytes_throws_with_illegal_input(string source, int offset, [CanBeNull] string expected)
     {
         byte[] sourceBytes = Encoding.ASCII.GetBytes(source);
-        ClassicAssert.AreEqual(expected is not null, ObjectId.TryParse(sourceBytes.AsSpan(offset, 40), out ObjectId? id));
+        ClassicAssert.AreEqual(expected is not null, ObjectId.TryParse(sourceBytes.AsSpan(offset, 40), out ObjectId id));
     }
 
     [Test]
     public void TryParse_returns_false_when_array_null()
     {
-        ClassicAssert.False(ObjectId.TryParse(default, out ObjectId? objectId));
-        ClassicAssert.Null(objectId);
+        ClassicAssert.False(ObjectId.TryParse(default, out ObjectId objectId));
+        ClassicAssert.IsTrue(objectId.IsZero);
         ClassicAssert.False(ObjectId.TryParse(default(Span<byte>), out objectId));
-        ClassicAssert.Null(objectId);
+        ClassicAssert.IsTrue(objectId.IsZero);
     }
 
     [Test]
@@ -279,8 +279,8 @@ public sealed partial class ObjectIdTests
     {
         byte[] bytes = new byte[ObjectId.Sha1CharCount];
 
-        ClassicAssert.False(ObjectId.TryParse(bytes.AsSpan(1), out ObjectId? objectId));
-        ClassicAssert.Null(objectId);
+        ClassicAssert.False(ObjectId.TryParse(bytes.AsSpan(1), out ObjectId objectId));
+        ClassicAssert.IsTrue(objectId.IsZero);
     }
 
     [Test]

--- a/tests/app/UnitTests/GitCommands.Tests/Git/Tag/GitTagControllerTest.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Git/Tag/GitTagControllerTest.cs
@@ -82,6 +82,6 @@ public class GitTagControllerTest
 
     private static GitCreateTagArgs CreateAnnotatedTagArgs()
     {
-        return new GitCreateTagArgs("tagname", ObjectId.Parse("0000000000000000000000000000000000000000"), TagOperation.Annotate, "hello world");
+        return new GitCreateTagArgs("tagname", ObjectId.Random(), TagOperation.Annotate, "hello world");
     }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/GitModuleTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/GitModuleTests.cs
@@ -356,7 +356,7 @@ public sealed partial class GitModuleTests
     }
 
     [Test, TestCaseSource(nameof(StagedStatuses))]
-    public void GetStagedStatus(ObjectId firstRevision, ObjectId secondRevision, ObjectId parentToSecond, StagedStatus status)
+    public void GetStagedStatus(ObjectId? firstRevision, ObjectId? secondRevision, ObjectId? parentToSecond, StagedStatus status)
     {
         StagedStatus stagedStatus = _gitModule.GetTestAccessor().GetStagedStatus(firstRevision, secondRevision, parentToSecond);
         ClassicAssert.AreEqual(status, stagedStatus);

--- a/tests/app/UnitTests/GitCommands.Tests/GitRevisionInfoProviderTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/GitRevisionInfoProviderTests.cs
@@ -30,9 +30,7 @@ public class GitRevisionInfoProviderTests
     {
         IGitItem item = Substitute.For<IGitItem>();
 
-        // ObjectId checks input, use Try to get an illegal value
-        ObjectId.TryParse("", out ObjectId? objectId);
-        item.ObjectId.Returns(objectId);
+        item.ObjectId.Returns((ObjectId?)null);
 
         ((Action)(() => _provider.LoadChildren(item))).Should().Throw<ArgumentException>();
     }

--- a/tests/app/UnitTests/GitCommands.Tests/Properties/VerifyModuleInitializer.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/Properties/VerifyModuleInitializer.cs
@@ -1,10 +1,14 @@
 ﻿using System.Runtime.CompilerServices;
+using GitExtensions.Extensibility.Git;
 
 namespace GitCommandsTests.Properties;
 
 internal class VerifyModuleInitializer
 {
     [ModuleInitializer]
-    public static void Init() =>
+    public static void Init()
+    {
         VerifierSettings.UseStrictJson();
+        VerifierSettings.IgnoreMembers(nameof(ObjectId.IsZeroOrArtificial));
+    }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=empty_commit.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=empty_commit.verified.json
@@ -1,14 +1,17 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "af0537262373a24bcf2b8b1f68447540776f3703",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
   "TreeGuid": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -30,6 +33,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=multi_pathfilter.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=multi_pathfilter.verified.json
@@ -1,14 +1,17 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "5899baad9014356f7a334da660a7b304b4b00da2",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
   "TreeGuid": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -30,6 +33,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=no_subject.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=no_subject.verified.json
@@ -1,20 +1,25 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
   "TreeGuid": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -36,6 +41,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=normal.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=normal.verified.json
@@ -1,20 +1,25 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
   "TreeGuid": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -36,6 +41,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=notes_data.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=notes_data.verified.json
@@ -1,20 +1,25 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
   "TreeGuid": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -36,6 +41,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=notes_empty.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=notes_empty.verified.json
@@ -1,20 +1,25 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
   "TreeGuid": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -36,6 +41,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=reflogselector.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=reflogselector.verified.json
@@ -1,20 +1,25 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
   "TreeGuid": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -36,6 +41,7 @@
   "ReflogSelector": "stash{0}",
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=reflogselector_empty.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=reflogselector_empty.verified.json
@@ -1,20 +1,25 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
   "TreeGuid": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -36,6 +41,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=simple_pathfilter.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=simple_pathfilter.verified.json
@@ -1,14 +1,17 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
   "TreeGuid": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -30,6 +33,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=subject_no_body.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=subject_no_body.verified.json
@@ -1,14 +1,17 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "6668f89f67eb51e823b3868d90c404c570698204",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
   "TreeGuid": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Drew Noakes",
@@ -30,6 +33,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=subject_starts_with_newline.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=subject_starts_with_newline.verified.json
@@ -1,9 +1,11 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "8452225978d76fc1a95b2fdc4a5b6dca16658ad6",
   "TreeGuid": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "IEVin",

--- a/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=vertical_tab.verified.json
+++ b/tests/app/UnitTests/GitCommands.Tests/RevisionReaderTests.TryParseRevision_test_testName=vertical_tab.verified.json
@@ -1,20 +1,25 @@
 ﻿{
   "ObjectId": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Guid": "0c350e248500e4e893e6d17dcc61591cc1cd64e7",
   "ParentIds": [
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     },
     {
+      "IsZero": false,
       "IsArtificial": false
     }
   ],
   "TreeGuid": {
+    "IsZero": false,
     "IsArtificial": false
   },
   "Author": "Gerhard Olsson",
@@ -36,6 +41,7 @@
   "ReflogSelector": null,
   "HasParent": true,
   "FirstParentId": {
+    "IsZero": false,
     "IsArtificial": false
   }
 }

--- a/tests/app/UnitTests/GitUI.Tests/CommandsDialogs/RememberFileContextMenuControllerTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/CommandsDialogs/RememberFileContextMenuControllerTests.cs
@@ -17,7 +17,7 @@ public class RememberFileContextMenuControllerTests
     /// <param name="name">The git blob name</param>
     /// <param name="id">The commit id</param>
     /// <returns>The Git commit id for the item, to get a predictable output</returns>
-    private static ObjectId GetFileBlobHash(string name, ObjectId id)
+    private static ObjectId? GetFileBlobHash(string name, ObjectId id)
     {
         return id;
     }

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/BlameControlTests.cs
@@ -193,7 +193,7 @@ public class BlameControlTests
         {
             DateTime lineDate = lineDates[index];
             yield return new GitBlameLine(
-                new GitBlameCommit(null!, "Author1", "@Author1", lineDate, string.Empty,
+                new GitBlameCommit(ObjectId.Random(), "Author1", "@Author1", lineDate, string.Empty,
                     "Commiter", "@Committer", lineDate, string.Empty, "Summary1", "file"),
                 index + 1, index + 1, "text");
         }

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/LocalBranchContextMenuProviderTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/LocalBranchContextMenuProviderTests.cs
@@ -11,7 +11,7 @@ public class LocalBranchContextMenuProviderTests
     private LocalBranchContextMenuProvider _provider = null!;
     private IGitUICommands _uiCommands = null!;
     private RefContextMenuContext _context = null!;
-    private ObjectId _currentCheckout = null!;
+    private ObjectId _currentCheckout = ObjectId.Random();
 
     [SetUp]
     public void Setup()

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/RemoteBranchContextMenuProviderTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/RemoteBranchContextMenuProviderTests.cs
@@ -11,7 +11,7 @@ public class RemoteBranchContextMenuProviderTests
     private RemoteBranchContextMenuProvider _provider = null!;
     private IGitUICommands _uiCommands = null!;
     private RefContextMenuContext _context = null!;
-    private ObjectId _currentCheckout = null!;
+    private ObjectId _currentCheckout = ObjectId.Random();
 
     [SetUp]
     public void Setup()

--- a/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/TagContextMenuProviderTests.cs
+++ b/tests/app/UnitTests/GitUI.Tests/UserControls/RevisionGrid/RefContextMenus/TagContextMenuProviderTests.cs
@@ -11,7 +11,7 @@ public class TagContextMenuProviderTests
     private TagContextMenuProvider _provider = null!;
     private IGitUICommands _uiCommands = null!;
     private RefContextMenuContext _context = null!;
-    private ObjectId _currentCheckout = null!;
+    private ObjectId _currentCheckout = ObjectId.Random();
 
     [SetUp]
     public void Setup()


### PR DESCRIPTION
Convert ObjectId from `sealed class` to `readonly struct`, eliminating heap allocations in hot paths (revision parsing, graph building, blame).

**Depends on #8** (fixed-size-buffer-objectid) — review/merge that first.

## Breaking change

`ObjectId` is now a value type:
- `ObjectId?` is `Nullable<ObjectId>` (not a nullable reference)
- `TryParse` out parameters: `out ObjectId` (not `out ObjectId?`, no `[NotNullWhen]`)
- `default(ObjectId)` is all-zeroes (not null) — use `IsZero` to check

## Key changes

### ObjectId.cs
- `sealed class` → `readonly struct`
- Add `IsZero` — detects the default (all-zeroes) value
- Add `IsZeroOrArtificial` — unified "not a real commit" check (excluded from Verify snapshots)

### Validation improvements
- `GitRevision` constructor rejects zero ObjectId
- `GitCreateTagArgs` constructor rejects zero/artificial ObjectId (validation moved earlier)
- `ArgumentBuilderExtensions.Add(ObjectId)` — new non-nullable overload that checks IsZero
- `RevisionReader.GetRevisionAsync` — `IsArtificial` check no longer incorrectly gated on cache flag

### API cleanups
- `TryResolvePartialCommitId` — `out ObjectId` (non-nullable)
- `IGitItem.ObjectId` — stays nullable (GitRef.NoHead needs it), now documented why
- Explicit `IGitItem.ObjectId` implementations in `GitRevision` and `GitItem`
- `GitSubmoduleInfo` — renamed param `currentCommitGuid` → `currentCommitId`

### Downstream fixes (77 files)
All `ObjectId?` → `Nullable<ObjectId>` migration across src/ and tests/: null checks, `.Value` access, TryParse signatures, test assertions, Verify snapshots.