### PR TITLE
feat: scroll revision grid to worktree commit on selection

### DIFF
--- a/src/app/GitCommands/CommitMessageManager.cs
+++ b/src/app/GitCommands/CommitMessageManager.cs
@@ -91,6 +91,7 @@ public sealed class CommitMessageManager : ICommitMessageManager
     internal CommitMessageManager(Control owner, string workingDirGitDir, Encoding commitEncoding, IFileSystem fileSystem, string? overriddenCommitMessage = null)
     {
         ArgumentNullException.ThrowIfNull(owner);
+        ArgumentNullException.ThrowIfNull(workingDirGitDir);
 
         _owner = owner;
         _fileSystem = fileSystem;
@@ -211,7 +212,7 @@ public sealed class CommitMessageManager : ICommitMessageManager
         return formattedCommitMessage.ToString();
     }
 
-    private string GetFilePath(string workingDirGitDir, string fileName) => _fileSystem.Path.Combine(workingDirGitDir, fileName);
+    private string GetFilePath(string workingDirGitDir, string fileName) => _fileSystem.Path.Join(workingDirGitDir, fileName);
 
     private string GetMergeOrCommitMessagePath() => IsMergeCommit ? MergeMessagePath : CommitMessagePath;
 

--- a/src/app/GitCommands/DiffMergeTools/SemanticMerge.cs
+++ b/src/app/GitCommands/DiffMergeTools/SemanticMerge.cs
@@ -24,8 +24,8 @@ internal class SemanticMerge : DiffMergeTool
         string folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         return
         [
-            Path.Combine(folder, @"semanticmerge"),
-            Path.Combine(folder, @"PlasticSCM4\semanticmerge")
+            Path.Join(folder, @"semanticmerge"),
+            Path.Join(folder, @"PlasticSCM4\semanticmerge")
         ];
     }
 }

--- a/src/app/GitCommands/DiffMergeTools/VsCode.cs
+++ b/src/app/GitCommands/DiffMergeTools/VsCode.cs
@@ -24,7 +24,7 @@ internal class VsCode : DiffMergeTool
         string folder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         return
         [
-            Path.Combine(folder, @"Programs\Microsoft VS Code"),
+            Path.Join(folder, @"Programs\Microsoft VS Code"),
             @"Microsoft VS Code\",
         ];
     }

--- a/src/app/GitCommands/DiffMergeTools/VsDiffMerge.cs
+++ b/src/app/GitCommands/DiffMergeTools/VsDiffMerge.cs
@@ -39,7 +39,7 @@ internal class VsDiffMerge : DiffMergeTool
             string? path = localMachineKey?.GetValue("InstallDir") as string;
             if (!string.IsNullOrEmpty(path))
             {
-                return Path.Combine(path, ExeName);
+                return Path.Join(path, ExeName);
             }
         }
 

--- a/src/app/GitCommands/Git/Commands.Execution.cs
+++ b/src/app/GitCommands/Git/Commands.Execution.cs
@@ -103,7 +103,7 @@ public static partial class Commands
             try
             {
                 // eg. "/path/to/repo/.git/HEAD"
-                string headFileName = Path.Combine(gitDirectory, "HEAD");
+                string headFileName = Path.Join(gitDirectory, "HEAD");
 
                 if (!File.Exists(headFileName))
                 {

--- a/src/app/GitCommands/Git/EnvironmentConfiguration.cs
+++ b/src/app/GitCommands/Git/EnvironmentConfiguration.cs
@@ -54,7 +54,7 @@ public static class EnvironmentConfiguration
 
         if (OperatingSystem.IsWindows())
         {
-            string sshAskPass = Path.Combine(AppSettings.GetInstallDir()!, "GitExtSshAskPass.exe");
+            string sshAskPass = Path.Join(AppSettings.GetInstallDir()!, "GitExtSshAskPass.exe");
 
             if (File.Exists(sshAskPass))
             {

--- a/src/app/GitCommands/Git/Extended/MoveCommand.cs
+++ b/src/app/GitCommands/Git/Extended/MoveCommand.cs
@@ -17,7 +17,7 @@ public sealed class MoveCommand(IExecutable _gitExecutable) : IExtendedCommand<M
             return;
         }
 
-        string fullPath = Path.Combine(workingDir, relativePath);
+        string fullPath = Path.Join(workingDir, relativePath);
         if (!Directory.Exists(fullPath))
         {
             Directory.CreateDirectory(fullPath);

--- a/src/app/GitCommands/Git/GitDirectoryResolver.cs
+++ b/src/app/GitCommands/Git/GitDirectoryResolver.cs
@@ -69,7 +69,7 @@ public sealed class GitDirectoryResolver : IGitDirectoryResolver
 
         // Workaround for links to .git directories on WSL
         bool isWslLink = false;
-        string gitPath = Path.Combine(repositoryPath, ".git");
+        string gitPath = Path.Join(repositoryPath, ".git");
         if (_fileSystem.File.Exists(gitPath))
         {
             const string gitdir = "gitdir:";
@@ -94,7 +94,7 @@ public sealed class GitDirectoryResolver : IGitDirectoryResolver
                     return path.EnsureTrailingPathSeparator();
                 }
 
-                return Path.GetFullPath(Path.Combine(repositoryPath, path)).EnsureTrailingPathSeparator();
+                return Path.GetFullPath(Path.Join(repositoryPath, path)).EnsureTrailingPathSeparator();
             }
         }
 

--- a/src/app/GitCommands/Git/GitModule.cs
+++ b/src/app/GitCommands/Git/GitModule.cs
@@ -102,7 +102,7 @@ public sealed partial class GitModule : IGitModule
 
             // If we didn't find it, but there's a .git file in the current folder, look for a gitdir:
             // line in that file that points to the location of the .git folder
-            string gitDir = Path.Combine(WorkingDir, ".git");
+            string gitDir = Path.Join(WorkingDir, ".git");
             if (superprojectPath is null && File.Exists(gitDir))
             {
                 IEnumerable<string> lines;
@@ -145,7 +145,7 @@ public sealed partial class GitModule : IGitModule
             }
 
             string submodulePath = currentPath[superprojectPath.Length..].ToPosixPath();
-            ConfigFile configFile = new(Path.Combine(superprojectPath, ".gitmodules"));
+            ConfigFile configFile = new(Path.Join(superprojectPath, ".gitmodules"));
 
             foreach (IConfigSection configSection in configFile.ConfigSections)
             {
@@ -160,7 +160,7 @@ public sealed partial class GitModule : IGitModule
             return (null, submodulePath);
 
             static bool HasGitModulesFile(string path)
-                => File.Exists(Path.Combine(path, ".gitmodules")) && IsValidGitWorkingDir(path);
+                => File.Exists(Path.Join(path, ".gitmodules")) && IsValidGitWorkingDir(path);
         }
     }
 
@@ -1939,7 +1939,7 @@ public sealed partial class GitModule : IGitModule
 
     public bool InTheMiddleOfBisect()
     {
-        return File.Exists(Path.Combine(_executor.GetGitDirectory(), "BISECT_START"));
+        return File.Exists(Path.Join(_executor.GetGitDirectory(), "BISECT_START"));
     }
 
     public bool InTheMiddleOfRebase() => InTheMiddleOfGitOperation("applying");
@@ -1954,7 +1954,7 @@ public sealed partial class GitModule : IGitModule
 
     public bool InTheMiddleOfMerge()
     {
-        return File.Exists(Path.Combine(_executor.GetGitDirectory(), "MERGE_HEAD"));
+        return File.Exists(Path.Join(_executor.GetGitDirectory(), "MERGE_HEAD"));
     }
 
     public bool InTheMiddleOfAction()
@@ -3698,7 +3698,7 @@ public sealed partial class GitModule : IGitModule
         }
 
         // Get processes by "ps" command.
-        string cmd = Path.Combine(AppSettings.LinuxToolsDir, "ps");
+        string cmd = Path.Join(AppSettings.LinuxToolsDir, "ps");
         string[] lines = new Executable(cmd).GetOutput("x").Split(Delimiters.LineFeed);
 
         if (lines.Length <= 2)

--- a/src/app/GitCommands/Git/IndexLockManager.cs
+++ b/src/app/GitCommands/Git/IndexLockManager.cs
@@ -49,7 +49,7 @@ public sealed class IndexLockManager : IIndexLockManager
     /// <returns><see langword="true"/> if index is locked; otherwise <see langword="false"/>.</returns>
     public bool IsIndexLocked()
     {
-        string indexLockFile = Path.Combine(_gitDirectoryResolver.Resolve(_module.WorkingDir), IndexLock);
+        string indexLockFile = Path.Join(_gitDirectoryResolver.Resolve(_module.WorkingDir), IndexLock);
         return _fileSystem.File.Exists(indexLockFile);
     }
 
@@ -62,7 +62,7 @@ public sealed class IndexLockManager : IIndexLockManager
     /// <exception cref="FileDeleteException">Unable to delete specific index.lock.</exception>
     public void UnlockIndex(bool includeSubmodules = true)
     {
-        string workingFolderIndexLock = Path.Combine(_gitDirectoryResolver.Resolve(_module.WorkingDir), IndexLock);
+        string workingFolderIndexLock = Path.Join(_gitDirectoryResolver.Resolve(_module.WorkingDir), IndexLock);
         if (!includeSubmodules)
         {
             DeleteIndexLock(workingFolderIndexLock);
@@ -74,7 +74,7 @@ public sealed class IndexLockManager : IIndexLockManager
         IEnumerable<string> list = submodules.Select(sm =>
         {
             string submodulePath = _module.GetSubmoduleFullPath(sm);
-            string submoduleIndexLock = Path.Combine(_gitDirectoryResolver.Resolve(submodulePath), IndexLock);
+            string submoduleIndexLock = Path.Join(_gitDirectoryResolver.Resolve(submodulePath), IndexLock);
             return submoduleIndexLock;
         }).Union(new[] { workingFolderIndexLock });
 

--- a/src/app/GitCommands/Git/Tag/GitTagController.cs
+++ b/src/app/GitCommands/Git/Tag/GitTagController.cs
@@ -44,7 +44,7 @@ public class GitTagController : IGitTagController
         string? tagMessageFileName = null;
         if (args.Operation.CanProvideMessage())
         {
-            tagMessageFileName = Path.Combine(GetWorkingDirPath(), "TAGMESSAGE");
+            tagMessageFileName = Path.Join(GetWorkingDirPath(), "TAGMESSAGE");
             _fileSystem.File.WriteAllText(tagMessageFileName, args.TagMessage);
         }
 

--- a/src/app/GitCommands/PathUtil.cs
+++ b/src/app/GitCommands/PathUtil.cs
@@ -389,7 +389,7 @@ public static partial class PathUtil
 
             foreach (string path in EnvironmentPathsProvider.GetEnvironmentValidPaths())
             {
-                fullPath = Path.Combine(path, fileName);
+                fullPath = Path.Join(path, fileName);
                 if (File.Exists(fullPath))
                 {
                     return true;
@@ -412,7 +412,7 @@ public static partial class PathUtil
             string? programW6432 = EnvironmentAbstraction.GetEnvironmentVariable("ProgramW6432");
             if (!string.IsNullOrEmpty(programW6432))
             {
-                shellPath = Path.Combine(programW6432, "Git", shell);
+                shellPath = Path.Join(programW6432, "Git", shell);
                 if (File.Exists(shellPath))
                 {
                     return true;
@@ -422,7 +422,7 @@ public static partial class PathUtil
             string programFilesX86 = EnvironmentAbstraction.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
             if (!string.IsNullOrEmpty(programFilesX86))
             {
-                shellPath = Path.Combine(programFilesX86, "Git", shell);
+                shellPath = Path.Join(programFilesX86, "Git", shell);
                 if (File.Exists(shellPath))
                 {
                     return true;
@@ -432,7 +432,7 @@ public static partial class PathUtil
             string linuxToolsDir = AppSettings.LinuxToolsDir;
             if (!string.IsNullOrEmpty(linuxToolsDir))
             {
-                shellPath = Path.Combine(linuxToolsDir, shell);
+                shellPath = Path.Join(linuxToolsDir, shell);
                 if (File.Exists(shellPath))
                 {
                     return true;
@@ -520,7 +520,7 @@ public static partial class PathUtil
                 continue;
             }
 
-            fullName = FindFileInEnvVarFolder("LOCALAPPDATA", Path.Combine("Programs", location), fileName)
+            fullName = FindFileInEnvVarFolder("LOCALAPPDATA", Path.Join("Programs", location), fileName)
                 ?? FindFileInEnvVarFolder("ProgramFiles", location, fileName)
                 ?? FindFileInEnvVarFolder("ProgramW6432", location, fileName);
             if (fullName is not null)
@@ -548,7 +548,7 @@ public static partial class PathUtil
                 return null;
             }
 
-            string path = Path.Combine(envVarFolder, location);
+            string path = Path.Join(envVarFolder, location);
             if (!Directory.Exists(path))
             {
                 return null;
@@ -559,7 +559,7 @@ public static partial class PathUtil
 
         static string? FindFile(string location, string fileName1)
         {
-            string fullName = Path.Combine(location, fileName1);
+            string fullName = Path.Join(location, fileName1);
             if (File.Exists(fullName))
             {
                 return fullName;

--- a/src/app/GitCommands/Remotes/AzureDevOpsRemoteParser.cs
+++ b/src/app/GitCommands/Remotes/AzureDevOpsRemoteParser.cs
@@ -5,16 +5,16 @@ namespace GitCommands.Remotes;
 
 public sealed partial class AzureDevOpsRemoteParser : RemoteParser
 {
-    [GeneratedRegex(@"^https:\/\/(?<owner>[^.]*)\.visualstudio\.com\/(?<project>[^\/]*)\/_git\/(?<repo>.*)$")]
+    [GeneratedRegex(@"^https:\/\/(?<owner>[^.]*)\.visualstudio\.com\/(?<project>[^\/]*)\/_git\/(?<repo>.*)$", RegexOptions.ExplicitCapture)]
     private static partial Regex VstsHttpsRemoteRegex { get; }
 
-    [GeneratedRegex(@"^[^@]*@vs-ssh\.visualstudio\.com:v\d\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/(?<repo>.*)$")]
+    [GeneratedRegex(@"^[^@]*@vs-ssh\.visualstudio\.com:v\d\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/(?<repo>.*)$", RegexOptions.ExplicitCapture)]
     private static partial Regex VstsSshRemoteRegex { get; }
 
-    [GeneratedRegex(@"^https:\/\/[^@]*@dev\.azure\.com\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/_git\/(?<repo>.*)$")]
+    [GeneratedRegex(@"^https:\/\/[^@]*@dev\.azure\.com\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/_git\/(?<repo>.*)$", RegexOptions.ExplicitCapture)]
     private static partial Regex AzureDevopsHttpsRemoteRegex { get; }
 
-    [GeneratedRegex(@"^git@ssh\.dev\.azure\.com:v\d\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/(?<repo>.*)$")]
+    [GeneratedRegex(@"^git@ssh\.dev\.azure\.com:v\d\/(?<owner>[^\/]*)\/(?<project>[^\/]*)\/(?<repo>.*)$", RegexOptions.ExplicitCapture)]
     private static partial Regex AzureDevopsSshRemoteRegex { get; }
 
     private static readonly Regex[] _azureDevopsRegexes = [AzureDevopsHttpsRemoteRegex, AzureDevopsSshRemoteRegex, VstsHttpsRemoteRegex, VstsSshRemoteRegex];

--- a/src/app/GitCommands/RevisionReader.cs
+++ b/src/app/GitCommands/RevisionReader.cs
@@ -353,7 +353,7 @@ public sealed class RevisionReader
 
     private static void AddAutoStash(string workingDirGitDir, IObserver<IReadOnlyList<GitRevision>> subject, string autostashLabel)
     {
-        string autoStashFileName = Path.Combine(workingDirGitDir, "rebase-merge/autostash");
+        string autoStashFileName = Path.Join(workingDirGitDir, "rebase-merge/autostash");
         if (!File.Exists(autoStashFileName)
             || !ObjectId.TryParse(File.ReadLines(autoStashFileName).FirstOrDefault(), out ObjectId? autoStashCommitId))
         {
@@ -369,7 +369,7 @@ public sealed class RevisionReader
             Subject = autostashLabel
         };
 
-        string origHeadFileName = Path.Combine(workingDirGitDir, "rebase-merge/orig-head");
+        string origHeadFileName = Path.Join(workingDirGitDir, "rebase-merge/orig-head");
         if (File.Exists(origHeadFileName)
             && ObjectId.TryParse(File.ReadLines(origHeadFileName).FirstOrDefault(), out ObjectId? origHeadCommitId))
         {

--- a/src/app/GitCommands/Settings/AppSettings.cs
+++ b/src/app/GitCommands/Settings/AppSettings.cs
@@ -31,8 +31,8 @@ public static partial class AppSettings
 
     public static Lazy<string?> ApplicationDataPath { get; private set; }
     public static readonly Lazy<string?> LocalApplicationDataPath;
-    public static string SettingsFilePath => Path.Combine(ApplicationDataPath.Value!, SettingsFileName);
-    public static string UserPluginsPath => Path.Combine(LocalApplicationDataPath.Value!, UserPluginsDirectoryName);
+    public static string SettingsFilePath => Path.Join(ApplicationDataPath.Value!, SettingsFileName);
+    public static string UserPluginsPath => Path.Join(LocalApplicationDataPath.Value!, UserPluginsDirectoryName);
 
     public static DistributedSettings SettingsContainer { get; private set; }
 
@@ -77,7 +77,7 @@ public static partial class AppSettings
                 return GetGitExtensionsDirectory();
             }
 
-            string path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), ApplicationId);
+            string path = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), ApplicationId);
             if (!Directory.Exists(path))
             {
                 Directory.CreateDirectory(path);
@@ -244,7 +244,7 @@ public static partial class AppSettings
             if (debugPath.ToPosixPath() == path.ToPosixPath())
             {
                 string projectPath = gitExtDir[..^len];
-                return Path.Combine(projectPath, "Bin");
+                return Path.Join(projectPath, "Bin");
             }
         }
 #endif
@@ -613,7 +613,7 @@ public static partial class AppSettings
 
     #region Avatars
 
-    public static string AvatarImageCachePath => Path.Combine(LocalApplicationDataPath.Value!, "Images\\");
+    public static string AvatarImageCachePath => Path.Join(LocalApplicationDataPath.Value!, "Images\\");
 
     public static AvatarFallbackType AvatarFallbackType
     {
@@ -1665,7 +1665,7 @@ public static partial class AppSettings
 
     public static string GetDictionaryDir()
     {
-        return Path.Combine(GetResourceDir()!, "Dictionaries");
+        return Path.Join(GetResourceDir()!, "Dictionaries");
     }
 
     public static void SaveSettings()

--- a/src/app/GitCommands/Settings/DistributedSettings.cs
+++ b/src/app/GitCommands/Settings/DistributedSettings.cs
@@ -35,7 +35,7 @@ public class DistributedSettings : SettingsContainer<DistributedSettings, GitExt
     private static DistributedSettings CreateLocal(IGitModule module, DistributedSettings? lowerPriority, SettingLevel settingLevel, bool useSharedCache = true)
     {
         return new DistributedSettings(lowerPriority,
-            GitExtSettingsCache.Create(Path.Combine(module.GitCommonDirectory, AppSettings.SettingsFileName), useSharedCache),
+            GitExtSettingsCache.Create(Path.Join(module.GitCommonDirectory, AppSettings.SettingsFileName), useSharedCache),
             settingLevel);
     }
 
@@ -47,7 +47,7 @@ public class DistributedSettings : SettingsContainer<DistributedSettings, GitExt
     private static DistributedSettings CreateDistributed(IGitModule module, DistributedSettings? lowerPriority, bool useSharedCache = true)
     {
         return new DistributedSettings(lowerPriority,
-            GitExtSettingsCache.Create(Path.Combine(module.WorkingDir, AppSettings.SettingsFileName), useSharedCache),
+            GitExtSettingsCache.Create(Path.Join(module.WorkingDir, AppSettings.SettingsFileName), useSharedCache),
             SettingLevel.Distributed);
     }
 

--- a/src/app/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
+++ b/src/app/GitCommands/UserRepositoryHistory/RepositoryDescriptionProvider.cs
@@ -118,7 +118,7 @@ public sealed class RepositoryDescriptionProvider : IRepositoryDescriptionProvid
     private string? ReadRepositoryDescription(string workingDir)
     {
         string gitDir = _gitDirectoryResolver.Resolve(workingDir);
-        string descriptionFilePath = Path.Combine(gitDir, _repositoryDescriptionFileName);
+        string descriptionFilePath = Path.Join(gitDir, _repositoryDescriptionFileName);
 
         if (!File.Exists(descriptionFilePath))
         {

--- a/src/app/GitExtensions.Extensibility/Translations/Translator.cs
+++ b/src/app/GitExtensions.Extensibility/Translations/Translator.cs
@@ -41,7 +41,7 @@ public static class Translator
 
     public static string GetTranslationDir()
     {
-        return Path.Combine(Path.GetDirectoryName(typeof(Translator).Assembly.Location)!, "Translation");
+        return Path.Join(Path.GetDirectoryName(typeof(Translator).Assembly.Location)!, "Translation");
     }
 
     public static string[] GetAllTranslations()

--- a/src/app/GitExtensions/Program.cs
+++ b/src/app/GitExtensions/Program.cs
@@ -275,7 +275,7 @@ internal static class Program
             // saves having to have a reference to System.Xml just to check that we have an XmlException
             if (in3?.GetType().Name == "XmlException")
             {
-                string localSettingsPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "GitExtensions");
+                string localSettingsPath = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "GitExtensions");
 
                 // assume that if we are having this error and the installation is not a portable one then the folder will exist.
                 if (Directory.Exists(localSettingsPath))

--- a/src/app/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
+++ b/src/app/GitUI/AutoCompletion/CommitAutoCompleteProvider.cs
@@ -99,7 +99,7 @@ public class CommitAutoCompleteProvider : IAutoCompleteProvider
 
         Validates.NotNull(appDataPath);
 
-        string path = Path.Combine(appDataPath, "AutoCompleteRegexes.txt");
+        string path = Path.Join(appDataPath, "AutoCompleteRegexes.txt");
 
         if (File.Exists(path))
         {

--- a/src/app/GitUI/Avatars/FileSystemAvatarCache.cs
+++ b/src/app/GitUI/Avatars/FileSystemAvatarCache.cs
@@ -47,7 +47,7 @@ public sealed class FileSystemAvatarCache : IAvatarProvider, IAvatarCacheCleaner
             return await _inner.GetAvatarAsync(email, name, imageSize);
         }
 
-        string path = Path.Combine(_cacheDir, $"{email}.{imageSize}px.png");
+        string path = Path.Join(_cacheDir, $"{email}.{imageSize}px.png");
 
         Image? image = ReadImage();
 

--- a/src/app/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
+++ b/src/app/GitUI/CommandsDialogs/BrowseDialog/GitStatusMonitor.cs
@@ -397,13 +397,13 @@ public sealed class GitStatusMonitor : IDisposable
                 if (isValidGitDir)
                 {
                     _gitDirWatcher.Path = PathUtil.RemoveTrailingPathSeparator(gitDirPath);
-                    _submodulesPath = Path.Combine(_gitPath!, "modules");
+                    _submodulesPath = Path.Join(_gitPath!, "modules");
                 }
                 else
                 {
                     // WSL link, FileSystemWatcher will throw on directories that are symbolic links
                     _gitDirWatcher.Path = workTreePath;
-                    _submodulesPath = Path.Combine(gitDirPath, "modules");
+                    _submodulesPath = Path.Join(gitDirPath, "modules");
                 }
 
                 CurrentStatus = GitStatusMonitorState.Running;

--- a/src/app/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
+++ b/src/app/GitUI/CommandsDialogs/FormAddToGitIgnore.cs
@@ -48,7 +48,7 @@ public sealed partial class FormAddToGitIgnore : GitModuleForm
             }
             else
             {
-                return Path.Combine(Module.ResolveGitInternalPath("info"), "exclude");
+                return Path.Join(Module.ResolveGitInternalPath("info"), "exclude");
             }
         }
     }

--- a/src/app/GitUI/CommandsDialogs/FormCommit.cs
+++ b/src/app/GitUI/CommandsDialogs/FormCommit.cs
@@ -171,7 +171,7 @@ public sealed partial class FormCommit : GitModuleForm
     /// <summary>
     /// Regex to find message replace pattern: {{ group1 }}[ group2 ]
     /// </summary>
-    [GeneratedRegex(@"\{\{(.*?)\}\}(?:\[(\d+)\])?")]
+    [GeneratedRegex(@"\{\{(?<pattern>.*?)\}\}(?:\[(?<index>\d+)\])?", RegexOptions.ExplicitCapture)]
     private static partial Regex ReplaceMessageRegex();
 
     private CommitKind CommitKind
@@ -1426,10 +1426,10 @@ public sealed partial class FormCommit : GitModuleForm
 
             foreach (Match regexMatch in ReplaceMessageRegex().Matches(message))
             {
-                string pattern = regexMatch.Groups[1].Value;
+                string pattern = regexMatch.Groups["pattern"].Value;
                 int groupIndex = 1;
 
-                if (regexMatch.Groups.Count > 2 && int.TryParse(regexMatch.Groups[2].Value, out int parsedIndex))
+                if (int.TryParse(regexMatch.Groups["index"].Value, out int parsedIndex))
                 {
                     groupIndex = parsedIndex;
                 }

--- a/src/app/GitUI/CommandsDialogs/FormGitIgnore.cs
+++ b/src/app/GitUI/CommandsDialogs/FormGitIgnore.cs
@@ -19,7 +19,7 @@ public sealed partial class FormGitIgnore : GitModuleForm
 
     #region default patterns
 
-    private static readonly string DefaultIgnorePatternsFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "GitExtensions/DefaultIgnorePatterns.txt");
+    private static readonly string DefaultIgnorePatternsFile = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "GitExtensions/DefaultIgnorePatterns.txt");
 
     private static readonly string[] DefaultIgnorePatterns =
     [

--- a/src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs
+++ b/src/app/GitUI/CommandsDialogs/FormResolveConflicts.cs
@@ -400,17 +400,17 @@ public partial class FormResolveConflicts : GitModuleForm
                 return false;
             }
 
-            string dir = Path.Combine(Path.GetDirectoryName(Application.ExecutablePath)!, "Diff-Scripts").EnsureTrailingPathSeparator();
+            string dir = Path.Join(Path.GetDirectoryName(Application.ExecutablePath)!, "Diff-Scripts").EnsureTrailingPathSeparator();
             if (Directory.Exists(dir))
             {
                 if (_mergeScripts.TryGetValue(extension!, out string? mergeScript) &&
-                    File.Exists(Path.Combine(dir!, mergeScript)))
+                    File.Exists(Path.Join(dir!, mergeScript)))
                 {
                     if (MessageBoxes.Show(this, string.Format(_uskUseCustomMergeScript.Text, mergeScript),
                                         _uskUseCustomMergeScriptCaption.Text, MessageBoxButtons.YesNo, MessageBoxIcon.Question) ==
                         DialogResult.Yes)
                     {
-                        UseMergeWithScript(fileName, Path.Combine(dir, mergeScript), baseFileName, localFileName, remoteFileName);
+                        UseMergeWithScript(fileName, Path.Join(dir, mergeScript), baseFileName, localFileName, remoteFileName);
 
                         return true;
                     }

--- a/src/app/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
+++ b/src/app/GitUI/CommandsDialogs/FormSparseWorkingCopyViewModel.cs
@@ -120,7 +120,7 @@ public class FormSparseWorkingCopyViewModel : INotifyPropertyChanged
     /// </summary>
     public FileInfo GetPathToSparseCheckoutFile()
     {
-        return new FileInfo(Path.Combine(_gitCommands.Module.ResolveGitInternalPath("info"), "sparse-checkout"));
+        return new FileInfo(Path.Join(_gitCommands.Module.ResolveGitInternalPath("info"), "sparse-checkout"));
     }
 
     /// <summary>

--- a/src/app/GitUI/CommandsDialogs/FormVerify.LostObject.cs
+++ b/src/app/GitUI/CommandsDialogs/FormVerify.LostObject.cs
@@ -154,7 +154,7 @@ partial class FormVerify
             else if (objectType == LostObjectType.Blob)
             {
                 string hash = objectId.ToString();
-                string blobPath = Path.Combine(module.WorkingDirGitDir, "objects", hash[..2], hash[2..ObjectId.Sha1CharCount]);
+                string blobPath = Path.Join(module.WorkingDirGitDir, "objects", hash[..2], hash[2..ObjectId.Sha1CharCount]);
                 result.Date = new FileInfo(blobPath).CreationTime;
             }
 

--- a/src/app/GitUI/CommandsDialogs/GitIgnoreDialog/GitLocalExcludeModel.cs
+++ b/src/app/GitUI/CommandsDialogs/GitIgnoreDialog/GitLocalExcludeModel.cs
@@ -34,7 +34,7 @@ public class GitLocalExcludeModel : Translate, IGitIgnoreDialogModel
 
     public string FormCaption => _editLocalExcludeTitle.Text;
 
-    public string ExcludeFile => Path.Combine(_module.ResolveGitInternalPath("info"), "exclude");
+    public string ExcludeFile => Path.Join(_module.ResolveGitInternalPath("info"), "exclude");
 
     public string FileOnlyInWorkingDirSupported => _localExcludeOnlyInWorkingDirSupported.Text;
 

--- a/src/app/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
+++ b/src/app/GitUI/CommandsDialogs/RepoHosting/CreatePullRequestForm.cs
@@ -95,7 +95,7 @@ public partial class CreatePullRequestForm : GitModuleForm
 
     private void LoadPRTemplate()
     {
-        string templatePath = Path.Combine(Module.WorkingDir, ".github", "PULL_REQUEST_TEMPLATE.md");
+        string templatePath = Path.Join(Module.WorkingDir, ".github", "PULL_REQUEST_TEMPLATE.md");
 
         if (!File.Exists(templatePath))
         {

--- a/src/app/GitUI/CommandsDialogs/RevisionDiffController.cs
+++ b/src/app/GitUI/CommandsDialogs/RevisionDiffController.cs
@@ -85,7 +85,7 @@ internal sealed class RevisionDiffController(Func<IGitModule> getModule, IFullPa
                 // TODO: allow cancel the whole sequence
 
                 Directory.CreateDirectory(targetDirectory);
-                string targetFileName = Path.Combine(targetDirectory, Path.GetFileName(selectedItemFullName)!).ToNativePath();
+                string targetFileName = Path.Join(targetDirectory, Path.GetFileName(selectedItemFullName)!).ToNativePath();
                 Debug.WriteLine($"Saving {selectedItemFullName} --> {targetFileName}");
 
                 GetModule().SaveBlobAs(targetFileName, $"{item.SecondRevision.Guid}:\"{item.Item.Name}\"");

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/CheckSettingsLogic.cs
@@ -141,7 +141,7 @@ public class CheckSettingsLogic
 
         // cygwin has old git version on windows and bash has a lot of bugs
         yield return @"C:\cygwin\";
-        yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        yield return Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "Programs", "Git\\");
     }
 

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/AppearanceSettingsPage.cs
@@ -94,7 +94,7 @@ public partial class AppearanceSettingsPage : SettingsPageWithHeader
         }
         else
         {
-            string dictionaryFile = string.Concat(Path.Combine(AppSettings.GetDictionaryDir(), AppSettings.Dictionary), ".dic");
+            string dictionaryFile = string.Concat(Path.Join(AppSettings.GetDictionaryDir(), AppSettings.Dictionary), ".dic");
             if (File.Exists(dictionaryFile))
             {
                 Dictionary.Items.Add(AppSettings.Dictionary);

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormChooseTranslation.cs
@@ -31,7 +31,7 @@ public partial class FormChooseTranslation : GitExtensionsForm
 
         foreach (string translation in translations)
         {
-            string imagePath = Path.Combine(Translator.GetTranslationDir(), translation + ".gif");
+            string imagePath = Path.Join(Translator.GetTranslationDir(), translation + ".gif");
             if (File.Exists(imagePath))
             {
                 Image image = Image.FromFile(imagePath);

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/FormFixHome.cs
@@ -45,7 +45,7 @@ public partial class FormFixHome : GitExtensionsForm
 
             try
             {
-                using FileStream fs = File.Open(Path.Combine(home, ".gitconfig"), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                using FileStream fs = File.Open(Path.Join(home, ".gitconfig"), FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 
                 // file is readable, no further checks
                 return false;
@@ -67,7 +67,7 @@ public partial class FormFixHome : GitExtensionsForm
                 try
                 {
                     if (!string.IsNullOrEmpty(candidate) &&
-                        File.Exists(Path.Combine(candidate, ".gitconfig")))
+                        File.Exists(Path.Join(candidate, ".gitconfig")))
                     {
                         return true;
                     }
@@ -139,7 +139,7 @@ public partial class FormFixHome : GitExtensionsForm
         try
         {
             string? userHomeDir = Environment.GetEnvironmentVariable("HOME", EnvironmentVariableTarget.User);
-            if (!string.IsNullOrEmpty(userHomeDir) && File.Exists(Path.Combine(userHomeDir, ".gitconfig")))
+            if (!string.IsNullOrEmpty(userHomeDir) && File.Exists(Path.Join(userHomeDir, ".gitconfig")))
             {
                 MessageBoxes.Show(this, string.Format(_gitconfigFoundHome.Text, userHomeDir), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 defaultHome.Checked = true;
@@ -157,7 +157,7 @@ public partial class FormFixHome : GitExtensionsForm
         {
             string path = Environment.GetEnvironmentVariable("HOMEDRIVE") +
                        Environment.GetEnvironmentVariable("HOMEPATH");
-            if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
+            if (!string.IsNullOrEmpty(path) && File.Exists(Path.Join(path, ".gitconfig")))
             {
                 MessageBoxes.Show(this, string.Format(_gitconfigFoundHomedrive.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 defaultHome.Checked = true;
@@ -174,7 +174,7 @@ public partial class FormFixHome : GitExtensionsForm
         try
         {
             string? path = Environment.GetEnvironmentVariable("USERPROFILE");
-            if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
+            if (!string.IsNullOrEmpty(path) && File.Exists(Path.Join(path, ".gitconfig")))
             {
                 MessageBoxes.Show(this, string.Format(_gitconfigFoundUserprofile.Text, path), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 userprofileHome.Checked = true;
@@ -191,7 +191,7 @@ public partial class FormFixHome : GitExtensionsForm
         try
         {
             string path = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-            if (!string.IsNullOrEmpty(path) && File.Exists(Path.Combine(path, ".gitconfig")))
+            if (!string.IsNullOrEmpty(path) && File.Exists(Path.Join(path, ".gitconfig")))
             {
                 MessageBoxes.Show(this, string.Format(_gitconfigFoundPersonalFolder.Text, Environment.GetFolderPath(Environment.SpecialFolder.Personal)),
                     "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/Pages/GitConfigSettingsPage.cs
@@ -18,7 +18,7 @@ public partial class GitConfigSettingsPage : GitConfigBaseSettingsPage
     private readonly GitConfigSettingsPageController _controller;
     private DiffMergeToolConfigurationManager? _diffMergeToolConfigurationManager;
 
-    [GeneratedRegex(@"\$(LOCAL|REMOTE|BASE|MERGED)")]
+    [GeneratedRegex(@"\$(?:LOCAL|REMOTE|BASE|MERGED)", RegexOptions.ExplicitCapture)]
     private static partial Regex WslRebaseRegex { get; }
 
     public GitConfigSettingsPage(IServiceProvider serviceProvider)

--- a/src/app/GitUI/CommandsDialogs/SettingsDialog/ShellExtension/ShellExtensionManager.cs
+++ b/src/app/GitUI/CommandsDialogs/SettingsDialog/ShellExtension/ShellExtensionManager.cs
@@ -106,7 +106,7 @@ public static class ShellExtensionManager
     {
         foreach (string binDirectory in GetBinDirectories())
         {
-            string filePath = Path.Combine(binDirectory, fileName);
+            string filePath = Path.Join(binDirectory, fileName);
             if (File.Exists(filePath))
             {
                 return filePath;

--- a/src/app/GitUI/GitUICommands.cs
+++ b/src/app/GitUI/GitUICommands.cs
@@ -99,7 +99,7 @@ public sealed class GitUICommands : IGitUICommands
 
     public void StartBatchFileProcessDialog(string batchFile)
     {
-        string tempFile = Path.Combine(Path.GetTempPath(), $"GitExtensions-{Guid.NewGuid():N}.cmd");
+        string tempFile = Path.Join(Path.GetTempPath(), $"GitExtensions-{Guid.NewGuid():N}.cmd");
 
         try
         {
@@ -875,7 +875,7 @@ public sealed class GitUICommands : IGitUICommands
     private bool StartResetChangesDialog(string[] names)
     {
         ImmutableHashSet<string> relativeFilePaths = [.. names.Select(fileName => Path.GetRelativePath(Module.WorkingDir, fileName).ToPosixPath())];
-        ImmutableHashSet<string> relativeFolderPaths = [.. relativeFilePaths.Where(name => Directory.Exists(Path.Combine(Module.WorkingDir, name)))];
+        ImmutableHashSet<string> relativeFolderPaths = [.. relativeFilePaths.Where(name => Directory.Exists(Path.Join(Module.WorkingDir, name)))];
         bool allItems = relativeFolderPaths.Contains(".");
         GitItemStatus[] selectedItems = [.. Module.GetAllChangedFilesWithSubmodulesStatus(cancellationToken: default)
             .Where(item => allItems || relativeFilePaths.Contains(item.Name) || relativeFolderPaths.Any(folder => item.Path.Value.StartsWith(folder)))];

--- a/src/app/GitUI/LeftPanel/WorktreeNode.cs
+++ b/src/app/GitUI/LeftPanel/WorktreeNode.cs
@@ -10,6 +10,16 @@ internal sealed class WorktreeNode(Tree tree, GitWorktree worktree, bool isCurre
     public GitWorktree Worktree { get; } = worktree;
     public bool IsCurrent { get; } = isCurrent;
 
+    internal override void OnSelected()
+    {
+        if (Tree.IgnoreSelectionChangedEvent)
+        {
+            return;
+        }
+
+        SelectRevision();
+    }
+
     internal override void OnDoubleClick()
     {
         if (!IsCurrent && !Worktree.IsDeleted)
@@ -34,6 +44,20 @@ internal sealed class WorktreeNode(Tree tree, GitWorktree worktree, bool isCurre
         {
             ((WorktreeTree)Tree).Refresh();
         }
+    }
+
+    private void SelectRevision()
+    {
+        if (Worktree.Sha1 is null)
+        {
+            return;
+        }
+
+        TreeViewNode.TreeView?.BeginInvoke(() =>
+        {
+            UICommands.BrowseRepo?.GoToRef(Worktree.Sha1, showNoRevisionMsg: true, toggleSelection: Control.ModifierKeys.HasFlag(Keys.Control));
+            TreeViewNode.TreeView?.Focus();
+        });
     }
 
     protected override FontStyle GetFontStyle()

--- a/src/app/GitUI/NBugReports/BugReportInvoker.cs
+++ b/src/app/GitUI/NBugReports/BugReportInvoker.cs
@@ -68,7 +68,7 @@ public static class BugReportInvoker
     {
         string tempFolder = Path.GetTempPath();
         string tempFileName = $"{AppSettings.ApplicationId}.{AppSettings.AppVersion}.{DateTime.Now:yyyyMMdd.HHmmssfff}.log";
-        string tempFile = Path.Combine(tempFolder, tempFileName);
+        string tempFile = Path.Join(tempFolder, tempFileName);
 
         try
         {

--- a/src/app/GitUI/ScriptsEngine/ScriptInfo.cs
+++ b/src/app/GitUI/ScriptsEngine/ScriptInfo.cs
@@ -7,7 +7,7 @@ namespace GitUI.ScriptsEngine;
 public partial class ScriptInfo
 {
     // Match a single '&' (lookahead to not be followed by a second '&')
-    [GeneratedRegex("&(?!&)")]
+    [GeneratedRegex("&(?!&)", RegexOptions.ExplicitCapture)]
     private static partial Regex MnemonicAmpersandRegex { get; }
 
     private Bitmap? _icon;

--- a/src/app/GitUI/ScriptsEngine/ScriptOptionsParser.cs
+++ b/src/app/GitUI/ScriptsEngine/ScriptOptionsParser.cs
@@ -17,7 +17,7 @@ public sealed partial class ScriptOptionsParser
 
     private const string head = "HEAD";
 
-    [GeneratedRegex(@"(?<!\\)""")]
+    [GeneratedRegex(@"(?<!\\)""", RegexOptions.ExplicitCapture)]
     private static partial Regex QuoteRegex { get; }
 
     /// <summary>

--- a/src/app/GitUI/SpellChecker/EditNetSpell.cs
+++ b/src/app/GitUI/SpellChecker/EditNetSpell.cs
@@ -376,7 +376,7 @@ public partial class EditNetSpell : GitModuleControl
         }
 
         IDetachedSettings detachedSettings = Settings.Detached();
-        string dictionaryFile = string.Concat(Path.Combine(AppSettings.GetDictionaryDir(), detachedSettings.Dictionary), ".dic");
+        string dictionaryFile = string.Concat(Path.Join(AppSettings.GetDictionaryDir(), detachedSettings.Dictionary), ".dic");
 
         if (_wordDictionary is null || _wordDictionary.DictionaryFile != dictionaryFile)
         {

--- a/src/app/GitUI/Theming/ThemePathProvider.cs
+++ b/src/app/GitUI/Theming/ThemePathProvider.cs
@@ -22,7 +22,7 @@ public class ThemePathProvider : IThemePathProvider
     {
         string appDirectory = AppSettings.GetGitExtensionsDirectory() ??
             throw new DirectoryNotFoundException("Application directory not found");
-        AppThemesDirectory = Path.Combine(appDirectory, Subdirectory);
+        AppThemesDirectory = Path.Join(appDirectory, Subdirectory);
 
         string? userDirectory = AppSettings.ApplicationDataPath.Value;
 
@@ -30,7 +30,7 @@ public class ThemePathProvider : IThemePathProvider
         // hence we don't have a separate directory for user themes
         UserThemesDirectory = string.Equals(appDirectory, userDirectory, StringComparison.OrdinalIgnoreCase)
             ? null
-            : Path.Combine(userDirectory!, Subdirectory);
+            : Path.Join(userDirectory!, Subdirectory);
 
         ThemeExtension = ".css";
     }
@@ -51,7 +51,7 @@ public class ThemePathProvider : IThemePathProvider
         if (id.IsBuiltin)
         {
             string name = id == ThemeId.DefaultLight ? ThemeId.InvariantThemeFileName : id.Name;
-            path = Path.Combine(AppThemesDirectory, name + ThemeExtension);
+            path = Path.Join(AppThemesDirectory, name + ThemeExtension);
         }
         else
         {
@@ -60,7 +60,7 @@ public class ThemePathProvider : IThemePathProvider
                 throw new InvalidOperationException("Portable mode only supports local themes");
             }
 
-            path = Path.Combine(UserThemesDirectory, id.Name + ThemeExtension);
+            path = Path.Join(UserThemesDirectory, id.Name + ThemeExtension);
         }
 
         return path;

--- a/src/app/GitUI/UserControls/RevisionGrid/IndexWatcher.cs
+++ b/src/app/GitUI/UserControls/RevisionGrid/IndexWatcher.cs
@@ -58,7 +58,7 @@ public sealed class IndexWatcher : IDisposable
                 GitIndexWatcher.IncludeSubdirectories = false;
                 GitIndexWatcher.EnableRaisingEvents = _enabled;
 
-                RefsWatcher.Path = Path.Combine(Module.GitCommonDirectory, "refs");
+                RefsWatcher.Path = Path.Join(Module.GitCommonDirectory, "refs");
                 RefsWatcher.IncludeSubdirectories = true;
                 RefsWatcher.EnableRaisingEvents = _enabled;
             }

--- a/src/app/GitUI/UserEnvironmentInformation.cs
+++ b/src/app/GitUI/UserEnvironmentInformation.cs
@@ -17,7 +17,7 @@ public static partial class UserEnvironmentInformation
     private static bool _dirty;
     private static string? _sha;
 
-    [GeneratedRegex(@"^Microsoft\.WindowsDesktop\.App\s+([\w.-]+)\s+.*$", RegexOptions.Multiline)]
+    [GeneratedRegex(@"^Microsoft\.WindowsDesktop\.App\s+(?<version>[\w.-]+)\s+.*$", RegexOptions.Multiline | RegexOptions.ExplicitCapture)]
     private static partial Regex DesktopAppRegex { get; }
     [GeneratedRegex(@"^", RegexOptions.Multiline | RegexOptions.ExplicitCapture)]
     private static partial Regex LineStartRegex { get; }
@@ -100,7 +100,7 @@ public static partial class UserEnvironmentInformation
         try
         {
             return GetDotnetDesktopRuntimeMatches(versions)
-                .Select(match => Parse(match.Groups[1].Value))
+                .Select(match => Parse(match.Groups["version"].Value))
                 .WhereNotNull();
         }
         catch (Exception ex)

--- a/src/app/GitUI/UserManual/SingleHtmlUserManual.cs
+++ b/src/app/GitUI/UserManual/SingleHtmlUserManual.cs
@@ -12,7 +12,7 @@ public class SingleHtmlUserManual : IProvideUserManual
         {
             if (_location is null)
             {
-                string path = Path.Combine(AppSettings.GetInstallDir()!, "help");
+                string path = Path.Join(AppSettings.GetInstallDir()!, "help");
                 Uri uri = new(path);
                 _location = uri.AbsolutePath;
             }

--- a/src/app/GitUI/WindowPositionList.cs
+++ b/src/app/GitUI/WindowPositionList.cs
@@ -33,7 +33,7 @@ public class WindowPosition
 
 public class WindowPositionList
 {
-    private static readonly string ConfigFilePath = Path.Combine(AppSettings.LocalApplicationDataPath.Value!, "WindowPositions.xml");
+    private static readonly string ConfigFilePath = Path.Join(AppSettings.LocalApplicationDataPath.Value!, "WindowPositions.xml");
     private static readonly XmlSerializer _serializer = new(typeof(WindowPositionList));
 
     public List<WindowPosition> WindowPositions { get; set; } = [];

--- a/src/app/GitUI/WindowsJumpListManager.cs
+++ b/src/app/GitUI/WindowsJumpListManager.cs
@@ -100,7 +100,7 @@ public sealed class WindowsJumpListManager : IWindowsJumpListManager
                 return;
             }
 
-            string baseFolder = Path.Combine(AppSettings.ApplicationDataPath.Value!, "Recent");
+            string baseFolder = Path.Join(AppSettings.ApplicationDataPath.Value!, "Recent");
             if (!Directory.Exists(baseFolder))
             {
                 Directory.CreateDirectory(baseFolder);
@@ -114,7 +114,7 @@ public sealed class WindowsJumpListManager : IWindowsJumpListManager
                 sb.Replace(c, '_');
             }
 
-            string path = Path.Combine(baseFolder, $"{sb}.gitext");
+            string path = Path.Join(baseFolder, $"{sb}.gitext");
             File.WriteAllText(path, workingDir);
             JumpList.AddToRecent(path);
             UpdateJumpList(); // in order to refresh at once

--- a/src/app/ResourceManager/SubmoduleResources.cs
+++ b/src/app/ResourceManager/SubmoduleResources.cs
@@ -11,7 +11,7 @@ namespace ResourceManager;
 public static partial class SubmoduleResources
 {
     private static readonly ICommitDataHeaderRenderer PlainCommitDataHeaderRenderer = new CommitDataHeaderRenderer(new MonospacedHeaderLabelFormatter(), new DateFormatter(), new MonospacedHeaderRenderStyleProvider(), null);
-    [GeneratedRegex(@"^(\s*\S+)\s+", RegexOptions.Multiline)]
+    [GeneratedRegex(@"^(?<prefix>\s*\S+)\s+", RegexOptions.Multiline | RegexOptions.ExplicitCapture)]
     private static partial Regex ReplaceTrailingSpacesWithTabRegex { get; }
 
     public static string GetSubmoduleText(IGitModule superproject, string name, string hash)
@@ -199,6 +199,6 @@ public static partial class SubmoduleResources
         }
 
         static string ReplaceTrailingSpacesWithTab(string input)
-            => ReplaceTrailingSpacesWithTabRegex.Replace(input, "$1\t");
+            => ReplaceTrailingSpacesWithTabRegex.Replace(input, "${prefix}\t");
     }
 }

--- a/src/plugins/BuildServerIntegration/GitlabIntegration/Settings/GitlabRemoteParser.cs
+++ b/src/plugins/BuildServerIntegration/GitlabIntegration/Settings/GitlabRemoteParser.cs
@@ -6,10 +6,10 @@ namespace GitExtensions.Plugins.GitlabIntegration.Settings;
 
 public partial class GitlabRemoteParser : RemoteParser
 {
-    [GeneratedRegex(@"git(?:@|://)(?<host>[^/]+)[:/](?<owner>[^/]+)/(?<repo>[\w_\.\-]+)\.git")]
+    [GeneratedRegex(@"git(?:@|://)(?<host>[^/]+)[:/](?<owner>[^/]+)/(?<repo>[\w_\.\-]+)\.git", RegexOptions.ExplicitCapture)]
     private static partial Regex GitlabSshUrlRegex { get; }
 
-    [GeneratedRegex(@"https?://(?<host>[^/@]+)/(?<owner>.+)/(?<repo>[\w_\.\-]+)(?:.git)?")]
+    [GeneratedRegex(@"https?://(?<host>[^/@]+)/(?<owner>.+)/(?<repo>[\w_\.\-]+)(?:\.git)?", RegexOptions.ExplicitCapture)]
     private static partial Regex GitlabHttpsUrlRegex { get; }
 
     private static readonly Regex[] _gitLabRegexes = [GitlabHttpsUrlRegex, GitlabSshUrlRegex];

--- a/src/plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
+++ b/src/plugins/GitUIPluginInterfaces/ManagedExtensibility.cs
@@ -46,7 +46,7 @@ public static class ManagedExtensibility
     {
         Stopwatch stopwatch = Stopwatch.StartNew();
 
-        string defaultPluginsPath = Path.Combine(new FileInfo(Application.ExecutablePath).Directory!.FullName, "Plugins");
+        string defaultPluginsPath = Path.Join(new FileInfo(Application.ExecutablePath).Directory!.FullName, "Plugins");
         string? userPluginsPath = UserPluginsPath;
 
         // The plugins that are bundled up with the app must follow this naming convention: GitExtensions.Plugins.*.dll

--- a/src/plugins/Gource/GourcePlugin.cs
+++ b/src/plugins/Gource/GourcePlugin.cs
@@ -96,15 +96,15 @@ public class GourcePlugin : GitPluginBase, IGitPluginForRepository
                 }
 
                 string downloadDir = Path.GetTempPath();
-                string fileName = Path.Combine(downloadDir, "gource.zip");
+                string fileName = Path.Join(downloadDir, "gource.zip");
                 int downloadSize = ThreadHelper.JoinableTaskFactory.Run(() => DownloadFileAsync(args.OwnerForm, gourceUrl, fileName));
                 if (downloadSize > 0)
                 {
                     MessageBoxes.Show(args.OwnerForm, string.Format(_bytesDownloaded.Text, downloadSize), "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                    Directory.CreateDirectory(Path.Combine(downloadDir, "gource"));
-                    UnZipFiles(args.OwnerForm, fileName, Path.Combine(downloadDir, "gource"), true);
+                    Directory.CreateDirectory(Path.Join(downloadDir, "gource"));
+                    UnZipFiles(args.OwnerForm, fileName, Path.Join(downloadDir, "gource"), true);
 
-                    string newGourcePath = Path.Combine(downloadDir, "gource\\gource.exe");
+                    string newGourcePath = Path.Join(downloadDir, "gource\\gource.exe");
                     if (File.Exists(newGourcePath))
                     {
                         MessageBoxes.Show(args.OwnerForm, _gourceDownloadedAndUnzipped.Text, "Information", MessageBoxButtons.OK, MessageBoxIcon.Information);

--- a/src/plugins/Gource/GourceStart.cs
+++ b/src/plugins/Gource/GourceStart.cs
@@ -80,7 +80,7 @@ public partial class GourceStart : ResourceManager.GitExtensionsFormBase
 
     private async Task<string> LoadAvatarsAsync()
     {
-        string gourceAvatarsDir = Path.Combine(Path.GetTempPath(), "GitAvatars");
+        string gourceAvatarsDir = Path.Join(Path.GetTempPath(), "GitAvatars");
 
         Directory.CreateDirectory(gourceAvatarsDir);
 
@@ -118,7 +118,7 @@ public partial class GourceStart : ResourceManager.GitExtensionsFormBase
                     return;
                 }
 
-                string filePath = Path.Combine(gourceAvatarsDir, filename);
+                string filePath = Path.Join(gourceAvatarsDir, filename);
                 image.Save(filePath, ImageFormat.Png);
             }
             catch

--- a/tests/app/UnitTests/GitCommands.Tests/CommitMessageManagerTests.cs
+++ b/tests/app/UnitTests/GitCommands.Tests/CommitMessageManagerTests.cs
@@ -60,7 +60,7 @@ public class CommitMessageManagerTests
         _directory = Substitute.For<DirectoryBase>();
 
         PathBase path = Substitute.For<PathBase>();
-        path.Combine(Arg.Any<string>(), Arg.Any<string>()).Returns(x => Path.Combine((string)x[0], (string)x[1]));
+        path.Join(Arg.Any<string>(), Arg.Any<string>()).Returns(x => Path.Join((string)x[0], (string)x[1]));
 
         _fileSystem = Substitute.For<IFileSystem>();
         _fileSystem.File.Returns(_file);


### PR DESCRIPTION
When a worktree is selected in the left panel, navigate the revision grid to the commit that worktree's HEAD points to.

Previously, clicking a worktree node in the left panel did nothing (only double-click switched to the worktree). Now single-click navigates the revision grid to the worktree's HEAD commit, consistent with how branch, tag, and stash nodes behave.

### Changes

- Override `OnSelected()` in `WorktreeNode` to call `SelectRevision()` (respecting `IgnoreSelectionChangedEvent`)
- Add `SelectRevision()` method that calls `GoToRef` with the worktree's SHA, following the same pattern as `LocalBranchNode`, `TagNode`, `StashNode`, etc.
- Gracefully skips bare worktrees where `Sha1` is null
- Supports Ctrl+click for toggle selection